### PR TITLE
fix(secrets/k8s): sanitize secrets before validation calls

### DIFF
--- a/pkg/halyard/validate.go
+++ b/pkg/halyard/validate.go
@@ -69,7 +69,7 @@ func (s *Service) buildValidationRequest(ctx context.Context, spinsvc v1alpha2.S
 
 	for _, f := range secCtx.FileCache {
 		// Get the key
-		k := path.Join(SecretRelativeFilenames, path.Base(f))
+		k := fmt.Sprintf("%s__%s", SecretRelativeFilenames, path.Base(f))
 		b, err := ioutil.ReadFile(f)
 		if err != nil {
 			return nil, err

--- a/pkg/halyard/validate.go
+++ b/pkg/halyard/validate.go
@@ -6,13 +6,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/armory/spinnaker-operator/pkg/apis/spinnaker/v1alpha2"
-	"github.com/ghodss/yaml"
+	"github.com/armory/spinnaker-operator/pkg/inspect"
+	"github.com/armory/spinnaker-operator/pkg/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	"io/ioutil"
 	"mime/multipart"
 	"net/http"
+	"path"
 	"strings"
 )
+
+// Relative file path used to store secrets in the config sent to Halyard
+const SecretRelativeFilenames = "secrets"
 
 type validationResponse []struct {
 	Message  string `json:"message,omitempty"`
@@ -35,13 +41,18 @@ func (s *Service) Validate(ctx context.Context, spinsvc v1alpha2.SpinnakerServic
 func (s *Service) buildValidationRequest(ctx context.Context, spinsvc v1alpha2.SpinnakerServiceInterface, failFast bool) (*http.Request, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
+
 	// Add config
 	cfg := spinsvc.GetSpinnakerConfig()
-	b, err := yaml.Marshal(cfg.Config)
+
+	// Sanitize secrets before validating
+	// This will also serve as a secret validation step
+	sanitizedCfg, err := inspect.SanitizeSecrets(ctx, SecretRelativeFilenames, cfg.Config)
 	if err != nil {
 		return nil, err
 	}
-	if err = s.addPart(writer, "config", b); err != nil {
+
+	if err := s.addObjectToRequest(writer, "config", sanitizedCfg); err != nil {
 		return nil, err
 	}
 	// Add required files
@@ -50,8 +61,25 @@ func (s *Service) buildValidationRequest(ctx context.Context, spinsvc v1alpha2.S
 			return nil, err
 		}
 	}
-	err = writer.Close()
+	// Add cached secret files
+	secCtx, err := secrets.FromContextWithError(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range secCtx.FileCache {
+		// Get the key
+		k := path.Join(SecretRelativeFilenames, path.Base(f))
+		b, err := ioutil.ReadFile(f)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.addPart(writer, k, b); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := writer.Close(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/halyard/validate_test.go
+++ b/pkg/halyard/validate_test.go
@@ -2,6 +2,7 @@ package halyard
 
 import (
 	"context"
+	"fmt"
 	"github.com/armory/spinnaker-operator/pkg/apis/spinnaker/v1alpha2"
 	"github.com/armory/spinnaker-operator/pkg/secrets"
 	"github.com/ghodss/yaml"
@@ -123,7 +124,7 @@ spec:
 		}
 		// Check all files cached are being sent
 		for _, f := range c.FileCache {
-			fc, _, err := req.FormFile(path.Join(SecretRelativeFilenames, path.Base(f)))
+			fc, _, err := req.FormFile(fmt.Sprintf("%s__%s", SecretRelativeFilenames, path.Base(f)))
 			if assert.Nil(t, err) {
 				// Read content
 				b, err := ioutil.ReadAll(fc)

--- a/pkg/halyard/validate_test.go
+++ b/pkg/halyard/validate_test.go
@@ -3,8 +3,12 @@ package halyard
 import (
 	"context"
 	"github.com/armory/spinnaker-operator/pkg/apis/spinnaker/v1alpha2"
+	"github.com/armory/spinnaker-operator/pkg/secrets"
+	"github.com/ghodss/yaml"
 	testing2 "github.com/go-logr/logr/testing"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"path"
 	"strings"
 	"testing"
 )
@@ -76,12 +80,56 @@ func TestValidationResult(t *testing.T) {
 }
 
 func TestValidationRequest(t *testing.T) {
+	s := `
+apiVersion: spinnaker.io/v1alpha2
+kind: SpinnakerService
+metadata:
+ name: test
+spec:
+ spinnakerConfig:
+   config:
+     providers:
+       token: encrypted:noop!mytoken
+       kubernetes:
+         accounts:
+         - name: acc1
+           kubeconfigFile: encryptedFile:noop!myfilecontent
+`
 	spinsvc := &v1alpha2.SpinnakerService{}
+	err := yaml.Unmarshal([]byte(s), spinsvc)
+	if !assert.Nil(t, err) {
+		return
+	}
 	h := &Service{url: "http://localhost:8064"}
-	req, err := h.buildValidationRequest(context.TODO(), spinsvc, true)
+
+	// Validation fails on a non initialized secret context
+	_, err = h.buildValidationRequest(context.TODO(), spinsvc, true)
+	if assert.NotNil(t, err) {
+		assert.Equal(t, "secret context not initialized", err.Error())
+	}
+
+	ctx := secrets.NewContext(context.TODO(), nil, "ns")
+	req, err := h.buildValidationRequest(ctx, spinsvc, true)
 	if assert.Nil(t, err) {
 		assert.Equal(t, "localhost:8064", req.URL.Host)
 		assert.Equal(t, req.URL.Query().Get("failFast"), "true")
 		assert.NotEmpty(t, req.URL.Query().Get("skipValidators"))
+		_ = req.ParseMultipartForm(32 << 20)
+		// Check we're sending 2 parts: config and a secret
+		assert.Equal(t, len(req.MultipartForm.File), 2)
+		c, err := secrets.FromContextWithError(ctx)
+		if !assert.Nil(t, err) {
+			return
+		}
+		// Check all files cached are being sent
+		for _, f := range c.FileCache {
+			fc, _, err := req.FormFile(path.Join(SecretRelativeFilenames, path.Base(f)))
+			if assert.Nil(t, err) {
+				// Read content
+				b, err := ioutil.ReadAll(fc)
+				assert.Nil(t, err)
+				assert.Equal(t, "myfilecontent", string(b))
+			}
+		}
 	}
 }

--- a/pkg/inspect/parse.go
+++ b/pkg/inspect/parse.go
@@ -164,11 +164,7 @@ func sanitizeSecretsReflect(ctx context.Context, v reflect.Value, stringHandler 
 		}
 		return nmv, nil
 	case reflect.Interface:
-		iv, err := sanitizeSecretsReflect(ctx, v.Elem(), stringHandler)
-		if err != nil {
-			return v, err
-		}
-		return iv, nil
+		return sanitizeSecretsReflect(ctx, v.Elem(), stringHandler)
 	}
 	return v, nil
 }

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -63,7 +63,8 @@ func DecodeAsFile(ctx context.Context, val string) (string, error) {
 	return s, err
 }
 
+// ShouldDecryptToValidate should we decrypt that value before sending to Halyard for validation?
+// For now we decrypt everything so the operator has to be authorized to.
 func ShouldDecryptToValidate(val string) bool {
-	e, _, _ := secrets.GetEngine(val)
-	return e == "k8s" || e == "noop"
+	return true
 }

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -65,5 +65,5 @@ func DecodeAsFile(ctx context.Context, val string) (string, error) {
 
 func ShouldDecryptToValidate(val string) bool {
 	e, _, _ := secrets.GetEngine(val)
-	return e == "k8s"
+	return e == "k8s" || e == "noop"
 }


### PR DESCRIPTION
This resolves any referenced secret before the config is sent to Halyard for validation. Passwords/tokens are directly replaced with their resolved value. File references (only supported via `encryptedFile`) are changed to `secrets/<the local temp file name>`. That secret file is then added to the config sent to Halyard under the `secrets` key.

- sanitize: interfaces and use relative secret file path
