### PR TITLE
fix(patch): Changed patch strategy to three way merge

### DIFF
--- a/integration_tests/testdata/spinnaker/overlay_kubernetes/role_binding-template.yml
+++ b/integration_tests/testdata/spinnaker/overlay_kubernetes/role_binding-template.yml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: spin-role-binding
+  name: spin-role-binding-{{.SpinNamespace}}
 subjects:
   - kind: ServiceAccount
     name: spin-sa

--- a/integration_tests/testdata/spinnaker/overlay_profiles/role_binding-template.yml
+++ b/integration_tests/testdata/spinnaker/overlay_profiles/role_binding-template.yml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: spin-role-binding
+  name: spin-role-binding-{{.SpinNamespace}}
 subjects:
   - kind: ServiceAccount
     name: spin-sa

--- a/pkg/deploy/spindeploy/transformer/expose_lb.go
+++ b/pkg/deploy/spindeploy/transformer/expose_lb.go
@@ -142,11 +142,7 @@ func (t *exposeLbTransformer) applyExposeServiceConfig(svc *corev1.Service, serv
 	} else {
 		svc.Spec.Type = corev1.ServiceType(exp.Service.Type)
 	}
-
-	annotations := exp.GetAggregatedAnnotations(serviceName)
-	if len(annotations) > 0 {
-		svc.Annotations = annotations
-	}
+	svc.Annotations = exp.GetAggregatedAnnotations(serviceName)
 }
 
 func (t *exposeLbTransformer) applyPortChanges(ctx context.Context, portName string, portDefault int32, overrideUrlName string, svc *corev1.Service) error {

--- a/pkg/deploy/spindeploy/transformer/expose_lb_test.go
+++ b/pkg/deploy/spindeploy/transformer/expose_lb_test.go
@@ -61,6 +61,21 @@ func TestTransformManifests_ExposedAggregatedAnnotations(t *testing.T) {
 	assert.Equal(t, expected, gen.Config["gate"].Service)
 }
 
+func TestTransformManifests_ExposedAnnotationsRemoved(t *testing.T) {
+	tr, spinSvc := th.setupTransformer(&exposeLbTransformerGenerator{}, "testdata/spinsvc_expose.yml", t)
+	gen := &generated.SpinnakerGeneratedConfig{}
+	test.AddServiceToGenConfig(gen, "gate", "testdata/output_service_lb.yml", t)
+	spinSvc.Spec.Expose.Service.Annotations = map[string]string{} // annotations removed from config
+
+	err := tr.TransformManifests(context.TODO(), nil, gen)
+	assert.Nil(t, err)
+
+	expected := &corev1.Service{}
+	test.ReadYamlFile("testdata/output_service_lb.yml", expected, t)
+	expected.Annotations = map[string]string{}
+	assert.Equal(t, expected, gen.Config["gate"].Service)
+}
+
 func TestTransformManifests_ExposedServiceTypeOverridden(t *testing.T) {
 	tr, spinSvc := th.setupTransformer(&exposeLbTransformerGenerator{}, "testdata/spinsvc_expose.yml", t)
 	gen := &generated.SpinnakerGeneratedConfig{}

--- a/vendor/k8s.io/apimachinery/pkg/util/jsonmergepatch/patch.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/jsonmergepatch/patch.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsonmergepatch
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/evanphx/json-patch"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/mergepatch"
+)
+
+// Create a 3-way merge patch based-on JSON merge patch.
+// Calculate addition-and-change patch between current and modified.
+// Calculate deletion patch between original and modified.
+func CreateThreeWayJSONMergePatch(original, modified, current []byte, fns ...mergepatch.PreconditionFunc) ([]byte, error) {
+	if len(original) == 0 {
+		original = []byte(`{}`)
+	}
+	if len(modified) == 0 {
+		modified = []byte(`{}`)
+	}
+	if len(current) == 0 {
+		current = []byte(`{}`)
+	}
+
+	addAndChangePatch, err := jsonpatch.CreateMergePatch(current, modified)
+	if err != nil {
+		return nil, err
+	}
+	// Only keep addition and changes
+	addAndChangePatch, addAndChangePatchObj, err := keepOrDeleteNullInJsonPatch(addAndChangePatch, false)
+	if err != nil {
+		return nil, err
+	}
+
+	deletePatch, err := jsonpatch.CreateMergePatch(original, modified)
+	if err != nil {
+		return nil, err
+	}
+	// Only keep deletion
+	deletePatch, deletePatchObj, err := keepOrDeleteNullInJsonPatch(deletePatch, true)
+	if err != nil {
+		return nil, err
+	}
+
+	hasConflicts, err := mergepatch.HasConflicts(addAndChangePatchObj, deletePatchObj)
+	if err != nil {
+		return nil, err
+	}
+	if hasConflicts {
+		return nil, mergepatch.NewErrConflict(mergepatch.ToYAMLOrError(addAndChangePatchObj), mergepatch.ToYAMLOrError(deletePatchObj))
+	}
+	patch, err := jsonpatch.MergePatch(deletePatch, addAndChangePatch)
+	if err != nil {
+		return nil, err
+	}
+
+	var patchMap map[string]interface{}
+	err = json.Unmarshal(patch, &patchMap)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal patch for precondition check: %s", patch)
+	}
+	meetPreconditions, err := meetPreconditions(patchMap, fns...)
+	if err != nil {
+		return nil, err
+	}
+	if !meetPreconditions {
+		return nil, mergepatch.NewErrPreconditionFailed(patchMap)
+	}
+
+	return patch, nil
+}
+
+// keepOrDeleteNullInJsonPatch takes a json-encoded byte array and a boolean.
+// It returns a filtered object and its corresponding json-encoded byte array.
+// It is a wrapper of func keepOrDeleteNullInObj
+func keepOrDeleteNullInJsonPatch(patch []byte, keepNull bool) ([]byte, map[string]interface{}, error) {
+	var patchMap map[string]interface{}
+	err := json.Unmarshal(patch, &patchMap)
+	if err != nil {
+		return nil, nil, err
+	}
+	filteredMap, err := keepOrDeleteNullInObj(patchMap, keepNull)
+	if err != nil {
+		return nil, nil, err
+	}
+	o, err := json.Marshal(filteredMap)
+	return o, filteredMap, err
+}
+
+// keepOrDeleteNullInObj will keep only the null value and delete all the others,
+// if keepNull is true. Otherwise, it will delete all the null value and keep the others.
+func keepOrDeleteNullInObj(m map[string]interface{}, keepNull bool) (map[string]interface{}, error) {
+	filteredMap := make(map[string]interface{})
+	var err error
+	for key, val := range m {
+		switch {
+		case keepNull && val == nil:
+			filteredMap[key] = nil
+		case val != nil:
+			switch typedVal := val.(type) {
+			case map[string]interface{}:
+				// Explicitly-set empty maps are treated as values instead of empty patches
+				if len(typedVal) == 0 {
+					if !keepNull {
+						filteredMap[key] = typedVal
+					}
+					continue
+				}
+
+				var filteredSubMap map[string]interface{}
+				filteredSubMap, err = keepOrDeleteNullInObj(typedVal, keepNull)
+				if err != nil {
+					return nil, err
+				}
+
+				// If the returned filtered submap was empty, this is an empty patch for the entire subdict, so the key
+				// should not be set
+				if len(filteredSubMap) != 0 {
+					filteredMap[key] = filteredSubMap
+				}
+
+			case []interface{}, string, float64, bool, int64, nil:
+				// Lists are always replaced in Json, no need to check each entry in the list.
+				if !keepNull {
+					filteredMap[key] = val
+				}
+			default:
+				return nil, fmt.Errorf("unknown type: %v", reflect.TypeOf(typedVal))
+			}
+		}
+	}
+	return filteredMap, nil
+}
+
+func meetPreconditions(patchObj map[string]interface{}, fns ...mergepatch.PreconditionFunc) (bool, error) {
+	// Apply the preconditions to the patch, and return an error if any of them fail.
+	for _, fn := range fns {
+		if !fn(patchObj) {
+			return false, fmt.Errorf("precondition failed for: %v", patchObj)
+		}
+	}
+	return true, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -500,6 +500,7 @@ k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/util/framer
 k8s.io/apimachinery/pkg/util/intstr
 k8s.io/apimachinery/pkg/util/json
+k8s.io/apimachinery/pkg/util/jsonmergepatch
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net


### PR DESCRIPTION
* Using three way merge strategy for patching. The "third" payload is used specifically for deletions. Regular two-way merges are used for additions/changes.
* Using a raw client to avoid reading stale data from cache.
* Fixed an issue in integration tests where cluster role bindings collide when running tests in parallel