### PR TITLE
fix(secrets): Replace k8s secrets for aws credentials with env vars

### DIFF
--- a/pkg/apis/spinnaker/v1alpha2/config.go
+++ b/pkg/apis/spinnaker/v1alpha2/config.go
@@ -12,11 +12,18 @@ func (s *SpinnakerConfig) GetServiceSettingsPropString(ctx context.Context, svc,
 	return inspect.GetObjectPropString(ctx, s.ServiceSettings, fmt.Sprintf("%s.%s", svc, prop))
 }
 
-// GetHalConfigPropString returns a property stored in halconfig
+// GetHalConfigPropString returns a property stored in halconfig, decrypting it if necessary
 // We use the dot notation including for arrays
 // e.g. providers.aws.accounts.0.name
 func (s *SpinnakerConfig) GetHalConfigPropString(ctx context.Context, prop string) (string, error) {
 	return inspect.GetObjectPropString(ctx, s.Config, prop)
+}
+
+// GetRawHalConfigPropString returns a property stored in halconfig
+// We use the dot notation including for arrays
+// e.g. providers.aws.accounts.0.name
+func (s *SpinnakerConfig) GetRawHalConfigPropString(prop string) (string, error) {
+	return inspect.GetRawObjectPropString(s.Config, prop)
 }
 
 // GetHalConfigObjectArray reads an untyped array

--- a/pkg/apis/spinnaker/v1alpha2/config.go
+++ b/pkg/apis/spinnaker/v1alpha2/config.go
@@ -31,9 +31,27 @@ func (s *SpinnakerConfig) GetHalConfigObjectArray(ctx context.Context, prop stri
 	return inspect.GetObjectArray(s.Config, prop)
 }
 
+// GetServiceConfigObjectArray reads an untyped array from profile config
+func (s *SpinnakerConfig) GetServiceConfigObjectArray(svc, prop string) ([]map[string]interface{}, error) {
+	p, ok := s.Profiles[svc]
+	if ok {
+		return inspect.GetObjectArray(p, prop)
+	}
+	return nil, nil
+}
+
 // SetHalConfigProp sets a property in the config
 func (s *SpinnakerConfig) SetHalConfigProp(prop string, value interface{}) error {
 	return inspect.SetObjectProp(s.Config, prop, value)
+}
+
+// SetServiceConfigProp sets a property in the profile config
+func (s *SpinnakerConfig) SetServiceConfigProp(svc, prop string, value interface{}) error {
+	p, ok := s.Profiles[svc]
+	if ok {
+		return inspect.SetObjectProp(p, prop, value)
+	}
+	return nil
 }
 
 // GetHalConfigPropBool returns a boolean property in halconfig
@@ -46,6 +64,15 @@ func (s *SpinnakerConfig) GetServiceConfigPropString(ctx context.Context, svc, p
 	p, ok := s.Profiles[svc]
 	if ok {
 		return inspect.GetObjectPropString(ctx, p, prop)
+	}
+	return "", nil
+}
+
+// GetRawServiceConfigPropString returns the value of the prop in a service profile file, without decrypting any secret reference.
+func (s *SpinnakerConfig) GetRawServiceConfigPropString(svc, prop string) (string, error) {
+	p, ok := s.Profiles[svc]
+	if ok {
+		return inspect.GetRawObjectPropString(p, prop)
 	}
 	return "", nil
 }

--- a/pkg/deploy/spindeploy/transformer/secrets_test.go
+++ b/pkg/deploy/spindeploy/transformer/secrets_test.go
@@ -1,7 +1,12 @@
 package transformer
 
 import (
+	"context"
 	"fmt"
+	secups "github.com/armory/go-yaml-tools/pkg/secrets"
+	"github.com/armory/spinnaker-operator/pkg/apis/spinnaker/v1alpha2"
+	"github.com/armory/spinnaker-operator/pkg/secrets"
+	"github.com/armory/spinnaker-operator/pkg/test"
 	"github.com/armory/spinnaker-operator/pkg/util"
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
@@ -202,4 +207,78 @@ echo "hello world!"
 		assert.Nil(t, err)
 		assert.Equal(t, c.file, string(s.Data[c.name]), fmt.Sprintf("file type %s should not be changed", c.name))
 	}
+}
+
+func TestReplaceK8sSecretsInAwsSecretKeys(t *testing.T) {
+	cfg := `
+config:
+   artifacts:
+     s3:
+       accounts:
+       - awsAccessKeyId: acc1AccessKey
+         awsSecretAccessKey: encrypted:k8s!n:testsecret!k:acc1Secret
+         name: acc-1
+       - awsAccessKeyId: acc2AccessKey
+         awsSecretAccessKey: encrypted:k8s!n:testsecret!k:acc2Secret
+         name: acc-2
+   canary:
+     serviceIntegrations:
+     - accounts:
+       - name: can-1
+         secretAccessKey: encrypted:k8s!n:testsecret!k:canSecret
+       name: aws
+   persistentStorage:
+     persistentStoreType: s3
+     s3:
+       accessKeyId: persistenceAccessKey
+       secretAccessKey: encrypted:k8s!n:testsecret!k:persistenceSecret
+   providers:
+     aws:
+       accessKeyId: providerAccessKey
+       enabled: true
+       secretAccessKey: encrypted:k8s!n:testsecret!k:providerSecret
+`
+	spinCfg := &v1alpha2.SpinnakerConfig{}
+	assert.Nil(t, yaml.Unmarshal([]byte(cfg), spinCfg))
+	tr := &secretsTransformer{k8sSecrets: &k8sSecretHolder{awsCredsByService: map[string]*awsCredentials{}}}
+	secups.Engines["k8s"] = func(ctx context.Context, isFile bool, params string) (secups.Decrypter, error) {
+		_, k := secrets.ParseKubernetesSecretParams(params)
+		return &test.DummyK8sSecretEngine{Secret: k}, nil
+	}
+	ctx := secrets.NewContext(context.TODO(), nil, "")
+	assert.Nil(t, tr.replaceK8sSecretsFromAwsKeys(spinCfg, ctx))
+	assert.Equal(t, "persistenceAccessKey", tr.k8sSecrets.awsCredsByService["front50"].accessKeyId)
+	assert.Equal(t, "encrypted:k8s!n:testsecret!k:persistenceSecret", tr.k8sSecrets.awsCredsByService["front50"].secretAccessKey)
+	assert.Equal(t, "acc2AccessKey", tr.k8sSecrets.awsCredsByService["clouddriver"].accessKeyId)
+	assert.Equal(t, "encrypted:k8s!n:testsecret!k:acc2Secret", tr.k8sSecrets.awsCredsByService["clouddriver"].secretAccessKey)
+	actual, err := yaml.Marshal(spinCfg)
+	assert.Nil(t, err)
+	expected := `config:
+  artifacts:
+    s3:
+      accounts:
+      - awsAccessKeyId: acc1AccessKey
+        awsSecretAccessKey: OVERRIDDEN_BY_ENV_VARS
+        name: acc-1
+      - awsAccessKeyId: acc2AccessKey
+        awsSecretAccessKey: OVERRIDDEN_BY_ENV_VARS
+        name: acc-2
+  canary:
+    serviceIntegrations:
+    - accounts:
+      - name: can-1
+        secretAccessKey: canSecret
+      name: aws
+  persistentStorage:
+    persistentStoreType: s3
+    s3:
+      accessKeyId: persistenceAccessKey
+      secretAccessKey: OVERRIDDEN_BY_ENV_VARS
+  providers:
+    aws:
+      accessKeyId: providerAccessKey
+      enabled: true
+      secretAccessKey: OVERRIDDEN_BY_ENV_VARS
+`
+	assert.Equal(t, expected, string(actual))
 }

--- a/pkg/inspect/getter.go
+++ b/pkg/inspect/getter.go
@@ -21,14 +21,22 @@ func GetObjectPropBool(obj interface{}, prop string, defaultVal bool) (bool, err
 }
 
 func GetObjectPropString(ctx context.Context, obj interface{}, prop string) (string, error) {
+	s, err := GetRawObjectPropString(obj, prop)
+	if err != nil {
+		return "", err
+	}
+	decoded, _, err := secrets.Decode(ctx, s)
+	return decoded, err
+}
+
+func GetRawObjectPropString(obj interface{}, prop string) (string, error) {
 	c, err := getObjectProp(obj, prop)
 	if err != nil {
 		return "", err
 	}
 	switch c.Kind() {
 	case reflect.String:
-		s, _, err := secrets.Decode(ctx, c.String())
-		return s, err
+		return c.String(), err
 	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64:
 		return strconv.FormatInt(c.Int(), 10), nil
 	case reflect.Float64:

--- a/pkg/test/test_utils.go
+++ b/pkg/test/test_utils.go
@@ -15,6 +15,19 @@ import (
 	"testing"
 )
 
+type DummyK8sSecretEngine struct {
+	Secret string
+	File   bool
+}
+
+func (s *DummyK8sSecretEngine) Decrypt() (string, error) {
+	return s.Secret, nil
+}
+
+func (s *DummyK8sSecretEngine) IsFile() bool {
+	return s.File
+}
+
 func ManifestToSpinService(manifestYaml string, t *testing.T) *v1alpha2.SpinnakerService {
 	svc := &v1alpha2.SpinnakerService{}
 	ReadYamlFile(manifestYaml, svc, t)


### PR DESCRIPTION
For AWS credentials, if a kubernetes secret reference is specified (`encrypted:k8s...`) then replace the secret reference by env vars in the container.

Example config inside the pod:
```
/opt/spinnaker/config/front50.yml:
spinnaker:
  s3:
    accessKeyId: AKIAYJIFACYPPZRK7KLJ
    secretAccessKey: OVERRIDDEN_BY_ENV_VARS
```
```
/home/spinnaker/.aws/credentials:
[default]
aws_access_key_id = AKIAYJIFACYPPZRK7KLJ
aws_secret_access_key = OVERRIDDEN_BY_ENV_VARS
```
Env vars:
```
AWS_SECRET_ACCESS_KEY=<real secret access key>
AWS_ACCESS_KEY_ID=AKIAYJIFACYPPZRK7KLJ
```