### PR TITLE
feat(release): Github action for patch releases

### DIFF
--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -1,0 +1,49 @@
+on:
+  repository_dispatch:
+    types: [patch-release]
+
+jobs:
+  patch-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.branch }}
+      - name: Validate branch and fetch tags
+        run: |
+          [[ ${{ github.event.client_payload.branch }} != release-* ]] && echo "Branch ${{ github.event.client_payload.branch }} is not a release branch" && exit 1
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Validate tag
+        run: |
+          bprefix=$(echo ${{ github.event.client_payload.branch }} | sed 's/release-//' | cut -d '.' -f 1,2)
+          vprefix=$(echo ${{ github.event.client_payload.version }} | cut -d '.' -f 1,2)
+          [[ $bprefix != $vprefix ]] && echo "Major-minor version mismatch between supplied branch name and version" && exit 1
+          git tag v${{ github.event.client_payload.version }}
+      - name: Update manifests version
+        run: |
+          cat deploy/operator/basic/deployment.yaml | sed "s|image: armory/spinnaker-operator:.*|image: armory/spinnaker-operator:${{ github.event.client_payload.version }}|" | sed "s|imagePullPolicy:.*|imagePullPolicy: IfNotPresent|" > deploy/operator/basic/deployment.yaml.new
+          mv deploy/operator/basic/deployment.yaml.new deploy/operator/basic/deployment.yaml
+          cat deploy/operator/cluster/deployment.yaml | sed "s|image: armory/spinnaker-operator:.*|image: armory/spinnaker-operator:${{ github.event.client_payload.version }}|" | sed "s|imagePullPolicy:.*|imagePullPolicy: IfNotPresent|" > deploy/operator/cluster/deployment.yaml.new
+          mv deploy/operator/cluster/deployment.yaml.new deploy/operator/cluster/deployment.yaml
+      - name: Archive manifests
+        run: tar -czvf manifests.tgz deploy/
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ github.event.client_payload.version }}
+          release_name: v${{ github.event.client_payload.version }}
+          draft: false
+          prerelease: true
+      - name: Upload manifests
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./manifests.tgz
+          asset_name: manifests.tgz
+          asset_content_type: application/zip

--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -6,19 +6,21 @@ jobs:
   patch-release:
     runs-on: ubuntu-latest
     steps:
+      - name: Determine release branch
+        id: branch_step
+        run: |
+          branch=release-$(echo ${{ github.event.client_payload.version }} | cut -d '.' -f 1,2).x
+          echo "Derived release branch: $branch (this branch must already exist for patch releases)"
+          echo "##[set-output name=branch;]$branch"
       - name: Checkout branch
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.client_payload.branch }}
-      - name: Validate branch and fetch tags
+          ref: ${{ steps.branch_step.outputs.branch }}
+      - name: Fetch tags
         run: |
-          [[ ${{ github.event.client_payload.branch }} != release-* ]] && echo "Branch ${{ github.event.client_payload.branch }} is not a release branch" && exit 1
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Validate tag
         run: |
-          bprefix=$(echo ${{ github.event.client_payload.branch }} | sed 's/release-//' | cut -d '.' -f 1,2)
-          vprefix=$(echo ${{ github.event.client_payload.version }} | cut -d '.' -f 1,2)
-          [[ $bprefix != $vprefix ]] && echo "Major-minor version mismatch between supplied branch name and version" && exit 1
           git tag v${{ github.event.client_payload.version }}
       - name: Update manifests version
         run: |


### PR DESCRIPTION
Github action to help with automation of patch releases.

This is meant to be triggered after CI passes and docker image for the new release is pushed to registry. CI would need to make a HTTP request to github dispatch endpoint for this repository, indicating the new image tag that must follow semver version format (x.y.z).

This action will then do the following:
- Make sure a release branch already exists for this version (i.e. version=0.1.0, branch=release-0.1.x)
- Make sure the version has not already been released (by checking if the tag already exists)
- Update docker image tag in operator `deployment.yml` files
- Compress manifest files
- Create the github release (which creates automatically the tag)
- Add manifests to release