### PR TITLE
fix(secrets/k8s): Create env vars for AWS secret keys in service profiles

### DIFF
--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -146,7 +146,10 @@ func TestSecretsAndDuplicateOverlay(t *testing.T) {
 	e.VerifyAccountsExist("/credentials", t,
 		Account{Name: "kube-s3-secret", Type: "kubernetes"},
 		Account{Name: "kube-k8s-secret", Type: "kubernetes"})
-	e.VerifyAccountsExist("/artifacts/credentials", t, Account{Name: "test-github-account", Types: []string{"github/file"}})
+	e.VerifyAccountsExist("/artifacts/credentials", t,
+		Account{Name: "test-github-account-s3", Types: []string{"github/file"}},
+		Account{Name: "test-github-account-k8s", Types: []string{"github/file"}},
+		Account{Name: "test-s3-account-1", Types: []string{"s3/object"}})
 	if t.Failed() {
 		return
 	}

--- a/integration_tests/testdata/spinnaker/overlay_secrets/kustomization.yml
+++ b/integration_tests/testdata/spinnaker/overlay_secrets/kustomization.yml
@@ -8,6 +8,8 @@ secretGenerator:
   - name: testsecrets
     files:
       - kubecfg
+    literals:
+      - github-token=supersecrettoken
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/integration_tests/testdata/spinnaker/overlay_secrets/spinnaker-template.yml
+++ b/integration_tests/testdata/spinnaker/overlay_secrets/spinnaker-template.yml
@@ -43,5 +43,12 @@ spec:
         github:
           enabled: true
           accounts:
-            - name: test-github-account
+            - name: test-github-account-s3
               token: encrypted:s3!b:{{.S3Bucket}}!f:secrets/secrets.yml!r:{{.S3BucketRegion}}!k:github.account.token
+            - name: test-github-account-k8s
+              token: encrypted:k8s!n:testsecrets!k:github-token
+        s3:
+          enabled: true
+          accounts:
+            - name: test-s3-account-1
+              region: us-west-2

--- a/pkg/deploy/spindeploy/transformer/secrets_test.go
+++ b/pkg/deploy/spindeploy/transformer/secrets_test.go
@@ -203,7 +203,7 @@ echo "hello world!"
 			Data: map[string][]byte{c.name: []byte(c.file)},
 		}
 		k := &kubernetesSecretCollector{}
-		err := k.mapSecrets(c.name, s)
+		err := k.mapSecrets(s)
 		assert.Nil(t, err)
 		assert.Equal(t, c.file, string(s.Data[c.name]), fmt.Sprintf("file type %s should not be changed", c.name))
 	}
@@ -247,10 +247,16 @@ config:
 	}
 	ctx := secrets.NewContext(context.TODO(), nil, "")
 	assert.Nil(t, tr.replaceK8sSecretsFromAwsKeys(spinCfg, ctx))
-	assert.Equal(t, "persistenceAccessKey", tr.k8sSecrets.awsCredsByService["front50"].accessKeyId)
-	assert.Equal(t, "encrypted:k8s!n:testsecret!k:persistenceSecret", tr.k8sSecrets.awsCredsByService["front50"].secretAccessKey)
-	assert.Equal(t, "acc2AccessKey", tr.k8sSecrets.awsCredsByService["clouddriver"].accessKeyId)
-	assert.Equal(t, "encrypted:k8s!n:testsecret!k:acc2Secret", tr.k8sSecrets.awsCredsByService["clouddriver"].secretAccessKey)
+	assert.Equal(t, "persistenceAccessKey", tr.k8sSecrets.awsCredsByService["front50"].genAccessKey.Value)
+	assert.Equal(t, "persistenceSecret", tr.k8sSecrets.awsCredsByService["front50"].genSecretKey.ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, "testsecret", tr.k8sSecrets.awsCredsByService["front50"].svcSecretKeys[0].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "persistenceSecret", tr.k8sSecrets.awsCredsByService["front50"].svcSecretKeys[0].ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, "acc2AccessKey", tr.k8sSecrets.awsCredsByService["clouddriver"].genAccessKey.Value)
+	assert.Equal(t, "acc2Secret", tr.k8sSecrets.awsCredsByService["clouddriver"].genSecretKey.ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, "testsecret", tr.k8sSecrets.awsCredsByService["clouddriver"].svcSecretKeys[0].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "acc1Secret", tr.k8sSecrets.awsCredsByService["clouddriver"].svcSecretKeys[0].ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, "testsecret", tr.k8sSecrets.awsCredsByService["clouddriver"].svcSecretKeys[1].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "acc2Secret", tr.k8sSecrets.awsCredsByService["clouddriver"].svcSecretKeys[1].ValueFrom.SecretKeyRef.Key)
 	actual, err := yaml.Marshal(spinCfg)
 	assert.Nil(t, err)
 	expected := `config:
@@ -258,10 +264,10 @@ config:
     s3:
       accounts:
       - awsAccessKeyId: acc1AccessKey
-        awsSecretAccessKey: OVERRIDDEN_BY_ENV_VARS
+        awsSecretAccessKey: ${CLOUDDRIVER_TESTSECRET_ACC1SECRET}
         name: acc-1
       - awsAccessKeyId: acc2AccessKey
-        awsSecretAccessKey: OVERRIDDEN_BY_ENV_VARS
+        awsSecretAccessKey: ${CLOUDDRIVER_TESTSECRET_ACC2SECRET}
         name: acc-2
   canary:
     serviceIntegrations:
@@ -273,12 +279,12 @@ config:
     persistentStoreType: s3
     s3:
       accessKeyId: persistenceAccessKey
-      secretAccessKey: OVERRIDDEN_BY_ENV_VARS
+      secretAccessKey: ${FRONT50_TESTSECRET_PERSISTENCESECRET}
   providers:
     aws:
       accessKeyId: providerAccessKey
       enabled: true
-      secretAccessKey: OVERRIDDEN_BY_ENV_VARS
+      secretAccessKey: ${CLOUDDRIVER_TESTSECRET_PROVIDERSECRET}
 `
 	assert.Equal(t, expected, string(actual))
 }
@@ -317,10 +323,16 @@ profiles:
 	}
 	ctx := secrets.NewContext(context.TODO(), nil, "")
 	assert.Nil(t, tr.replaceK8sSecretsFromAwsKeys(spinCfg, ctx))
-	assert.Equal(t, "persistenceAccessKey", tr.k8sSecrets.awsCredsByService["front50"].accessKeyId)
-	assert.Equal(t, "encrypted:k8s!n:testsecret!k:persistenceSecret", tr.k8sSecrets.awsCredsByService["front50"].secretAccessKey)
-	assert.Equal(t, "acc2AccessKey", tr.k8sSecrets.awsCredsByService["clouddriver"].accessKeyId)
-	assert.Equal(t, "encrypted:k8s!n:testsecret!k:acc2Secret", tr.k8sSecrets.awsCredsByService["clouddriver"].secretAccessKey)
+	assert.Equal(t, "persistenceAccessKey", tr.k8sSecrets.awsCredsByService["front50"].genAccessKey.Value)
+	assert.Equal(t, "persistenceSecret", tr.k8sSecrets.awsCredsByService["front50"].genSecretKey.ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, "testsecret", tr.k8sSecrets.awsCredsByService["front50"].svcSecretKeys[0].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "persistenceSecret", tr.k8sSecrets.awsCredsByService["front50"].svcSecretKeys[0].ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, "acc2AccessKey", tr.k8sSecrets.awsCredsByService["clouddriver"].genAccessKey.Value)
+	assert.Equal(t, "acc2Secret", tr.k8sSecrets.awsCredsByService["clouddriver"].genSecretKey.ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, "testsecret", tr.k8sSecrets.awsCredsByService["clouddriver"].svcSecretKeys[0].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "acc1Secret", tr.k8sSecrets.awsCredsByService["clouddriver"].svcSecretKeys[0].ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, "testsecret", tr.k8sSecrets.awsCredsByService["clouddriver"].svcSecretKeys[1].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "acc2Secret", tr.k8sSecrets.awsCredsByService["clouddriver"].svcSecretKeys[1].ValueFrom.SecretKeyRef.Key)
 	actual, err := yaml.Marshal(spinCfg)
 	assert.Nil(t, err)
 	expected := `profiles:
@@ -329,22 +341,22 @@ profiles:
       s3:
         accounts:
         - awsAccessKeyId: acc1AccessKey
-          awsSecretAccessKey: OVERRIDDEN_BY_ENV_VARS
+          awsSecretAccessKey: ${CLOUDDRIVER_TESTSECRET_ACC1SECRET}
           name: acc-1
         - awsAccessKeyId: acc2AccessKey
-          awsSecretAccessKey: OVERRIDDEN_BY_ENV_VARS
+          awsSecretAccessKey: ${CLOUDDRIVER_TESTSECRET_ACC2SECRET}
           name: acc-2
     providers:
       aws:
         accessKeyId: providerAccessKey
         enabled: true
-        secretAccessKey: OVERRIDDEN_BY_ENV_VARS
+        secretAccessKey: ${CLOUDDRIVER_TESTSECRET_PROVIDERSECRET}
   front50:
     persistentStorage:
       persistentStoreType: s3
       s3:
         accessKeyId: persistenceAccessKey
-        secretAccessKey: OVERRIDDEN_BY_ENV_VARS
+        secretAccessKey: ${FRONT50_TESTSECRET_PERSISTENCESECRET}
 `
 	assert.Equal(t, expected, string(actual))
 }


### PR DESCRIPTION
This PR fixes 2 things:
* When there are S3 artifacts configured but no keys provided (so using worker node IAM role), AND kubernetes secrets are used elsewhere, an empty inner struct was created that made empty `env` references available to clouddriver Deployment, making clouddriver unable to be deployed due to invalid deployment spec.
* S3 artifact accounts can have individual access/secret keys configured instead of using the global AWS env vars.
Before:
```
    artifacts:
      s3:
        accounts:
        - awsAccessKeyId: acc1AccessKey
          awsSecretAccessKey: OVERRIDDEN_BY_ENV_VARS
          name: acc-1
```
Now:
```
    artifacts:
      s3:
        accounts:
        - awsAccessKeyId: acc1AccessKey
          awsSecretAccessKey: ${CLOUDDRIVER_TESTSECRET_ACC1SECRET}
          name: acc-1
```