### PR TITLE
chore(security): Fix some security violations by updating base image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.1-alpine3.9 as builder
+FROM golang:1.13.8-alpine3.11 as builder
 
 # vendor flags conflict with `go get`
 # so we fetch golint before running make


### PR DESCRIPTION
Updated base image for fixing security violations:
* Go /x/crypto/cryptobyte asn.1 parsing function certificate handling remote dos
* Net/url in go before 1.11.13 and 1.12.x before 1.12.8 mishandles malformed hosts in urls, leading to an authorization bypass in some applications. this is related to a host field with a suffix appearing in neither hostname() nor port(), and is related to a non-numeric port number. for example, an attacker can compose a crafted javascript:// url that results in a hostname of google.com.

There's still one security violation caused by `aws-iam-authenticator`, for which there's no newer version yet:
* Go through 1.12.5 on windows mishandles process creation with a nil environment in conjunction with a non-nil token, which allows attackers to obtain sensitive information or gain privileges.