### PR TITLE
fix(webhook/server-dry-run): Set SideEffect to "None"

### DIFF
--- a/pkg/controller/webhook/webhook.go
+++ b/pkg/controller/webhook/webhook.go
@@ -149,7 +149,14 @@ func deployValidatingWebhookConfiguration(svcName, ns string, rawClient *kuberne
 					Resources:   []string{r.r}, // should be "spinnakerservices"
 				},
 			}},
+			SideEffects: sideEffect(v1beta1.SideEffectClassNone),
 		})
 	}
 	return util.CreateOrUpdateValidatingWebhookConfiguration(webhookConfig, rawClient)
+}
+
+func sideEffect(sideEffect v1beta1.SideEffectClass) *v1beta1.SideEffectClass {
+	s := new(v1beta1.SideEffectClass)
+	*s = sideEffect
+	return s
 }


### PR DESCRIPTION
Fixes #100 running `--server-dry-run`

### Test case tested  

- Installed operator and webhook with SideEffect = "None" on cluster mode

![image](https://user-images.githubusercontent.com/16300174/77501436-a932b100-6e1d-11ea-9831-952a681ca56d.png)

- Having a spinnaker instance running

- Execute --server-dry-run with a wrong version of spinnaker

![image](https://user-images.githubusercontent.com/16300174/77501749-8d7bda80-6e1e-11ea-9c20-45352627692a.png)

![image](https://user-images.githubusercontent.com/16300174/77501797-ac7a6c80-6e1e-11ea-8fb4-10b246b49e94.png)

- [x] Existing spinnaker instance kept the state
 
- Execute --server-dry-run with a correct new version of spinnaker

![image](https://user-images.githubusercontent.com/16300174/77502168-af299180-6e1f-11ea-97b8-fe4257984d32.png)

- [x] Existing spinnaker instance kept the state
 
- [x] Applied changes on spinnaker service and existing spinnaker instance was updated  