### PR TITLE
feat(docs/migrate-from-halyard): add how to migrate from halyard to operator documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Set your own values in `deploy/spinnaker/kustomize/kustomization.yml`, then:
 $ kubectl create ns <spinnaker-namespace>
 $ kustomize build deploy/spinnaker/kustomize/ | kubectl -n <spinnaker-namespace> apply -f -
 ```
+
+## Migrate from Halyard to Operator
+See [how to migrate from halyard to Spinnaker Operatr](doc/migrate.md).
  
 ## SpinnakerService options
 See [all SpinnakerService options](doc/options.md).

--- a/doc/migrate.md
+++ b/doc/migrate.md
@@ -7,138 +7,128 @@ configuration files and start using operator.
 
 The migration process from halyard to Operator can be completed in n steps:
 
-1. Install Operator.
+1. To get started, [install](../README.md) Spinnaker Operator. 
 2. Export Spinnaker configuration.
-3. Export Spinnaker profiles.
-4. Export Spinnaker settings.
-5. Export Spinnaker files. 
-6. Prevalidate your spinnaker configuration (only cluster mode).
-7. Apply your SpinnakerService
 
-### 1. Install Operator
-
-To get started, [install](../README.md) Spinnaker Operator. 
-
-### 2. Export Spinnaker configuration 
-
-From the `config` file copy content of desired profile 
-
-Lets say you want to migrate `default` hal profile, then you will have the following structure:
-
-```yaml
-currentDeployment: default
-deploymentConfigurations:
-- name: default
-  <<CONTENT>> 
-```
-
-Where `<<CONTENT>>` needs to be added under `spec.spinnakerConfig.config` on `SpinnakerService` manifest as follows:
-
-```yaml
-spec:
-  spinnakerConfig:
-    config:
+    From the `config` file copy content of desired profile 
+    
+    Lets say you want to migrate `default` hal profile, then you will have the following structure:
+    
+    ```yaml
+    currentDeployment: default
+    deploymentConfigurations:
+    - name: default
       <<CONTENT>> 
-```
+    ```
+    
+    Where `<<CONTENT>>` needs to be added under `spec.spinnakerConfig.config` on `SpinnakerService` manifest as follows:
+    
+    ```yaml
+    spec:
+      spinnakerConfig:
+        config:
+          <<CONTENT>> 
+    ```
+    
+    Note: `config` is under `~/.hal`
+    
+    More details on [SpinnakerService Options](options.md) on `.spec.spinnakerConfig.config` section
 
-Note: `config` is under `~/.hal`
+3. Export Spinnaker profiles.
 
-More details on [SpinnakerService Options](options.md) on `.spec.spinnakerConfig.config` section
+    If we have configured spinnaker profiles, we will need to migrate these profiles to `SpinnakerService` manifest.
+    
+    Let's identify the current profiles under  `~/.hal/default/profiles`
+    
+    For each file let's create an entry under `spec.spinnakerConfig.profiles`
+    
+    Lets say we have the following profiles 
+    
+    ```bash
+    $ ls -a ~/.hal/default/profiles | sort
+    echo-local.yml
+    ```
+    
+    We need to create new entry with the name of the file without `-local.yaml` as follows:
+    
+    ```yaml
+    spec:
+      spinnakerConfig:
+        profiles:
+          echo: 
+            <<CONTENT>>
+    ```
+    
+    More details on [SpinnakerService Options](options.md) on `.spec.spinnakerConfig.profiles` section
 
-### 3. Export Spinnaker profiles
+4. Export Spinnaker settings.
+    
+    If we have configured spinnaker settings, we will need to migrate these profiles to `SpinnakerService` manifest.
+    
+    Let's identify the current settings under  `~/.hal/default/service-settings`
+    
+    For each file let's create an entry under `spec.spinnakerConfig.service-settings`
+    
+    Lets say we have the following settings 
+    
+    ```bash
+    $ ls -a ~/.hal/default/service-settings | sort
+    echo.yml
+    ```
+    
+    We need to create new entry with the name of the file without `.yaml` as follows:
+    
+    ```yaml
+    spec:
+      spinnakerConfig:
+        service-settings: 
+          echo:
+            <<CONTENT>>
+    ```
 
-If we have configured spinnaker profiles, we will need to migrate these profiles to `SpinnakerService` manifest.
+5. Export Spinnaker files. 
+    
+    If we have configured spinnaker files, we will need to migrate these files to `SpinnakerService` manifest.
+    
+    Let's identify the current files under  `~/.hal/default/profiles`
+    
+    For each file let's create an entry under `spec.spinnakerConfig.files`
+    
+    Lets say we have the following files 
+    
+    ```bash
+    $ tree -v ~/.hal/default/profiles
+    ├── echo.yml
+    └── rosco
+        └── packer
+            └── example-packer-config.json
+    
+    2 directories, 2 files
+    ```
+    
+    We need to create new entry with the name of the file following  this instructions:
+     
+    - For each folder put the folder name followed by double underscores (__) and at the very end the name of the file.
+    
+    ```yaml
+    spec:
+      spinnakerConfig:
+        files: 
+          profiles__rosco__packer__example-packer-config.json:
+            <<CONTENT>>
+    ```
 
-Let's identify the current profiles under  `~/.hal/default/profiles`
+6. Prevalidate your spinnaker configuration (only cluster mode).
+    
+    ```bash
+    $ kubectl -n <namespace> apply -f <spinnaker service> --server-dry-run
+    ```
+    
+    If something is wrong with your manifest validation service will throw an error.
 
-For each file let's create an entry under `spec.spinnakerConfig.profiles`
+7. Apply your SpinnakerService
+    
+    ```bash
+    $ kubectl -n <namespace> apply -f <spinnaker service>
+    ``` 
 
-Lets say we have the following profiles 
-
-```bash
-$ ls -a ~/.hal/default/profiles | sort
-echo-local.yml
-```
-
-We need to create new entry with the name of the file without `-local.yaml` as follows:
-
-```yaml
-spec:
-  spinnakerConfig:
-    profiles:
-      echo: 
-        <<CONTENT>>
-```
-
-More details on [SpinnakerService Options](options.md) on `.spec.spinnakerConfig.profiles` section
-
-### 4. Export Spinnaker settings
-
-If we have configured spinnaker settings, we will need to migrate these profiles to `SpinnakerService` manifest.
-
-Let's identify the current settings under  `~/.hal/default/service-settings`
-
-For each file let's create an entry under `spec.spinnakerConfig.service-settings`
-
-Lets say we have the following settings 
-
-```bash
-$ ls -a ~/.hal/default/service-settings | sort
-echo.yml
-```
-
-We need to create new entry with the name of the file without `.yaml` as follows:
-
-```yaml
-spec:
-  spinnakerConfig:
-    service-settings: 
-      echo:
-        <<CONTENT>>
-```
-
-### 5. Export Spinnaker files
-
-If we have configured spinnaker files, we will need to migrate these files to `SpinnakerService` manifest.
-
-Let's identify the current files under  `~/.hal/default/profiles`
-
-For each file let's create an entry under `spec.spinnakerConfig.files`
-
-Lets say we have the following files 
-
-```bash
-$ tree -v ~/.hal/default/profiles
-├── echo.yml
-└── rosco
-    └── packer
-        └── example-packer-config.json
-
-2 directories, 2 files
-```
-
-We need to create new entry with the name of the file following  this instructions:
- 
-- For each folder put the folder name followed by double underscores (__) and at the very end the name of the file.
-
-```yaml
-spec:
-  spinnakerConfig:
-    files: 
-      profiles__rosco__packer__example-packer-config.json:
-        <<CONTENT>>
-```
-
-### 6. Prevalidate your spinnaker configuration (only cluster mode)
-
-```bash
-$ kubectl -n <namespace> apply -f <spinnaker service> --server-dry-run
-```
-
-If something is wrong with your manifest validation service will throw an error.
-
-### 7. Apply your SpinnakerService
-
-```bash
-$ kubectl -n <namespace> apply -f <spinnaker service>
-```

--- a/doc/migrate.md
+++ b/doc/migrate.md
@@ -135,7 +135,7 @@ spec:
 $ kubectl -n <namespace> apply -f <spinnaker service> --server-dry-run
 ```
 
-If something is wrong with your manifest, the validation service will throw an error.
+If something is wrong with your manifest validation service will throw an error.
 
 ### 7. Apply your SpinnakerService
 

--- a/doc/migrate.md
+++ b/doc/migrate.md
@@ -1,0 +1,101 @@
+# Migrating from halyard to Operator
+
+If you have a current spinnaker instance installed via halyard, you can use this guide to take the existing 
+configuration files and start using operator.
+
+## Moving from halyard to Operator
+
+The migration process from halyard to Operator can be completed in n steps:
+
+1. Install Operator.
+2. Export Spinnaker configuration.
+3. Export Spinnaker profiles.
+4. Export Spinnaker settings.
+4. Export Spinnaker files.
+n. Prevalidate your spinnaker configuration (only cluster mode).
+
+### 1. Install Operator
+
+To get started, install [Spinnaker Operator](https://github.com/armory/spinnaker-operator/blob/master/README.md#L69). 
+
+### 2. Export Spinnaker configuration 
+
+From the `config` file copy content of desired profile 
+
+Lets say you want to migrate `default` hal profile, then you will have the following structure:
+
+```yaml
+currentDeployment: default
+deploymentConfigurations:
+- name: default
+  <<CONTENT>> 
+```
+
+Where `<<CONTENT>>` needs to be added under `spec.spinnakerConfig.config` on `SpinnakerService` manifest as follows:
+
+```yaml
+spec:
+  spinnakerConfig:
+    config:
+      <<CONTENT>> 
+```
+
+Note: `config` is under `~/.hal`
+
+### 3. Export Spinnaker profiles
+
+If we have configured spinnaker profiles, we will need to migrate these profiles to `SpinnakerService` manifest.
+
+Let's identify the current profiles under  `~/.hal/default/profiles`
+
+For each file let's create an entry under `spec.spinnakerConfig.profiles`
+
+Lets say we have the following profiles 
+
+```bash
+$ ls -a ~/.hal/default/profiles | sort
+echo-local.yml
+```
+
+We need to create new entry with the name of the file without `-local.yaml` as follows:
+
+```yaml
+spec:
+  spinnakerConfig:
+    profiles:
+      echo: 
+        <<CONTENT>>
+```
+
+### 4. Export Spinnaker settings
+
+If we have configured spinnaker settings, we will need to migrate these profiles to `SpinnakerService` manifest.
+
+Let's identify the current settings under  `~/.hal/default/service-settings`
+
+For each file let's create an entry under `spec.spinnakerConfig.service-settings`
+
+Lets say we have the following settings 
+
+```bash
+$ ls -a ~/.hal/default/service-settings | sort
+echo.yml
+```
+
+We need to create new entry with the name of the file without `.yaml` as follows:
+
+```yaml
+spec:
+  spinnakerConfig:
+    service-settings: 
+      echo:
+        <<CONTENT>>
+```
+
+
+### n. Prevalidate your spinnaker configuration (only cluster mode)
+
+```bash
+$ kubectl -n <namespace> apply -f <spinnaker service> --server-dry-run
+```
+

--- a/doc/migrate.md
+++ b/doc/migrate.md
@@ -43,6 +43,8 @@ spec:
 
 Note: `config` is under `~/.hal`
 
+More details on [SpinnakerService Options](options.md) on `.spec.spinnakerConfig.config` section
+
 ### 3. Export Spinnaker profiles
 
 If we have configured spinnaker profiles, we will need to migrate these profiles to `SpinnakerService` manifest.
@@ -67,6 +69,8 @@ spec:
       echo: 
         <<CONTENT>>
 ```
+
+More details on [SpinnakerService Options](options.md) on `.spec.spinnakerConfig.profiles` section
 
 ### 4. Export Spinnaker settings
 

--- a/doc/migrate.md
+++ b/doc/migrate.md
@@ -11,12 +11,13 @@ The migration process from halyard to Operator can be completed in n steps:
 2. Export Spinnaker configuration.
 3. Export Spinnaker profiles.
 4. Export Spinnaker settings.
-4. Export Spinnaker files.
-n. Prevalidate your spinnaker configuration (only cluster mode).
+5. Export Spinnaker files. 
+6. Prevalidate your spinnaker configuration (only cluster mode).
+7. Apply your SpinnakerService
 
 ### 1. Install Operator
 
-To get started, install [Spinnaker Operator](https://github.com/armory/spinnaker-operator/blob/master/README.md#L69). 
+To get started, [install](../README.md) Spinnaker Operator. 
 
 ### 2. Export Spinnaker configuration 
 
@@ -92,10 +93,48 @@ spec:
         <<CONTENT>>
 ```
 
+### 5. Export Spinnaker files
 
-### n. Prevalidate your spinnaker configuration (only cluster mode)
+If we have configured spinnaker files, we will need to migrate these files to `SpinnakerService` manifest.
+
+Let's identify the current files under  `~/.hal/default/profiles`
+
+For each file let's create an entry under `spec.spinnakerConfig.files`
+
+Lets say we have the following files 
+
+```bash
+$ tree -v ~/.hal/default/profiles
+├── echo.yml
+└── rosco
+    └── packer
+        └── example-packer-config.json
+
+2 directories, 2 files
+```
+
+We need to create new entry with the name of the file following  this instructions:
+ 
+- For each folder put the folder name followed by double underscores (__) and at the very end the name of the file.
+
+```yaml
+spec:
+  spinnakerConfig:
+    files: 
+      profiles__rosco__packer__example-packer-config.json:
+        <<CONTENT>>
+```
+
+### 6. Prevalidate your spinnaker configuration (only cluster mode)
 
 ```bash
 $ kubectl -n <namespace> apply -f <spinnaker service> --server-dry-run
 ```
 
+If something is wrong with your manifest, the validation service will throw an error.
+
+### 7. Apply your SpinnakerService
+
+```bash
+$ kubectl -n <namespace> apply -f <spinnaker service>
+```

--- a/doc/migrate.md
+++ b/doc/migrate.md
@@ -1,27 +1,25 @@
-# Migrating from halyard to Operator
+# Migrating from Halyard to Operator
 
-If you have a current spinnaker instance installed via halyard, you can use this guide to take the existing 
-configuration files and start using operator.
+If you have a current Spinnaker instance installed via Halyard, use this guide to migrate existing 
+configuration to Operator.
 
-## Moving from halyard to Operator
+The migration process from Halyard to Operator can be completed in 7 steps:
 
-The migration process from halyard to Operator can be completed in n steps:
-
-1. To get started, [install](../README.md) Spinnaker Operator. 
+1. To get started, install Spinnaker Operator. 
 2. Export Spinnaker configuration.
 
-    From the `config` file copy content of desired profile 
+    Copy the desired profile's content from the `config` file 
     
-    Lets say you want to migrate `default` hal profile, then you will have the following structure:
+    For example, if you want to migrate the `default` hal profile, use the following `SpinnakerService` manifest structure:
     
     ```yaml
     currentDeployment: default
     deploymentConfigurations:
     - name: default
-      <<CONTENT>> 
+      <CONTENT> 
     ```
     
-    Where `<<CONTENT>>` needs to be added under `spec.spinnakerConfig.config` on `SpinnakerService` manifest as follows:
+    Add `<CONTENT>` in the `spec.spinnakerConfig.config` section in the `SpinnakerService` manifest as follows:
     
     ```yaml
     spec:
@@ -36,69 +34,138 @@ The migration process from halyard to Operator can be completed in n steps:
 
 3. Export Spinnaker profiles.
 
-    If we have configured spinnaker profiles, we will need to migrate these profiles to `SpinnakerService` manifest.
+    If you have configured Spinnaker profiles, you will need to migrate these profiles to the `SpinnakerService` manifest.
     
-    Let's identify the current profiles under  `~/.hal/default/profiles`
+    First, identify the current profiles under  `~/.hal/default/profiles`
     
-    For each file let's create an entry under `spec.spinnakerConfig.profiles`
+    For each file, create an entry under `spec.spinnakerConfig.profiles`
     
-    Lets say we have the following profiles 
+    For example, you have the following profile: 
     
     ```bash
     $ ls -a ~/.hal/default/profiles | sort
     echo-local.yml
     ```
     
-    We need to create new entry with the name of the file without `-local.yaml` as follows:
+    Create a new entry with the name of the file without `-local.yaml` as follows:
     
     ```yaml
     spec:
       spinnakerConfig:
         profiles:
           echo: 
-            <<CONTENT>>
+            <CONTENT>
     ```
     
     More details on [SpinnakerService Options](options.md) on `.spec.spinnakerConfig.profiles` section
 
 4. Export Spinnaker settings.
+
+    If you configured Spinnaker settings, you need to migrate these settings to the `SpinnakerService` manifest also.
     
-    If we have configured spinnaker settings, we will need to migrate these profiles to `SpinnakerService` manifest.
+    First, identify the current settings under  `~/.hal/default/service-settings`
     
-    Let's identify the current settings under  `~/.hal/default/service-settings`
+    For each file, create an entry under `spec.spinnakerConfig.service-settings`
     
-    For each file let's create an entry under `spec.spinnakerConfig.service-settings`
-    
-    Lets say we have the following settings 
+    For example, you have the following settings: 
     
     ```bash
     $ ls -a ~/.hal/default/service-settings | sort
     echo.yml
     ```
     
-    We need to create new entry with the name of the file without `.yaml` as follows:
+   Create a new entry with the name of the file without `.yaml` as follows:
     
     ```yaml
     spec:
       spinnakerConfig:
         service-settings: 
           echo:
-            <<CONTENT>>
+            <CONTENT>
     ```
+    More details on [SpinnakerService Options](options.md) on `.spec.spinnakerConfig.service-settings` section
 
-5. Export Spinnaker files. 
+5. Export local file references.
+
+    If you have references to local files in any part of the config, like `kubeconfigFile`, service account json files or others, you need to migrate these files to the `SpinnakerService` manifest.
     
-    If we have configured spinnaker files, we will need to migrate these files to `SpinnakerService` manifest.
+    For each file, create an entry under `spec.spinnakerConfig.files`
     
-    Let's identify the current files under  `~/.hal/default/profiles`
+    For example, you have a Kubernetes account configured like this:
     
-    For each file let's create an entry under `spec.spinnakerConfig.files`
+    ```yaml
+    kubernetes:
+      enabled: true
+      accounts:
+      - name: prod
+        requiredGroupMembership: []
+        providerVersion: V2
+        permissions: {}
+        dockerRegistries: []
+        configureImagePullSecrets: true
+        cacheThreads: 1
+        namespaces: []
+        omitNamespaces: []
+        kinds: []
+        omitKinds: []
+        customResources: []
+        cachingPolicies: []
+        oAuthScopes: []
+        onlySpinnakerManaged: false
+        kubeconfigFile: /home/spinnaker/.hal/secrets/kubeconfig-prod
+      primaryAccount: prod
+    ```
     
-    Lets say we have the following files 
+    The `kubeconfigFile` field is a reference to a physical file on the machine running Halyard. You need to create a new entry in `files` section like this:
+     
+    ```yaml
+    spec:
+      spinnakerConfig:
+        files: 
+          kubeconfig-prod: |
+            <CONTENT>
+    ```
+    
+    Then replace the file path in the config to match the key in the `files` section:
+    
+    ```yaml
+    kubernetes:
+      enabled: true
+      accounts:
+      - name: prod
+        requiredGroupMembership: []
+        providerVersion: V2
+        permissions: {}
+        dockerRegistries: []
+        configureImagePullSecrets: true
+        cacheThreads: 1
+        namespaces: []
+        omitNamespaces: []
+        kinds: []
+        omitKinds: []
+        customResources: []
+        cachingPolicies: []
+        oAuthScopes: []
+        onlySpinnakerManaged: false
+        kubeconfigFile: kubeconfig-prod  # File name must match "files" key
+      primaryAccount: prod
+    ```
+    
+    More details on [SpinnakerService Options](options.md) on `.spec.spinnakerConfig.files` section
+    
+6. Export Packer template files (if used). 
+
+    If you are using custom Packer templates for baking images, you need to migrate these files to the `SpinnakerService` manifest.
+    
+    First, identify the current templates under  `~/.hal/default/profiles/rosco/packer`
+    
+    For each file, reate an entry under `spec.spinnakerConfig.files`
+    
+    For example, you have the following `example-packer-config` file:
     
     ```bash
     $ tree -v ~/.hal/default/profiles
-    ├── echo.yml
+    ├── echo-local.yml
     └── rosco
         └── packer
             └── example-packer-config.json
@@ -106,29 +173,29 @@ The migration process from halyard to Operator can be completed in n steps:
     2 directories, 2 files
     ```
     
-    We need to create new entry with the name of the file following  this instructions:
+    You need to create a new entry with the name of the file following these instructions:
      
-    - For each folder put the folder name followed by double underscores (__) and at the very end the name of the file.
+    - For each file, list the folder name starting with `profiles`, followed by double underscores (`__`) and at the very end the name of the file.
     
     ```yaml
     spec:
       spinnakerConfig:
         files: 
-          profiles__rosco__packer__example-packer-config.json:
-            <<CONTENT>>
+          profiles__rosco__packer__example-packer-config.json: |
+            <CONTENT>
     ```
+    More details on [SpinnakerService Options](options.md) on `.spec.spinnakerConfig.files` section
 
-6. Prevalidate your spinnaker configuration (only cluster mode).
-    
+6. Validate your Spinnaker configuration if you plan to run the Operator in cluster mode.
+
     ```bash
-    $ kubectl -n <namespace> apply -f <spinnaker service> --server-dry-run
+    $ kubectl -n <namespace> apply -f <spinnaker service manifest> --server-dry-run
     ```
     
-    If something is wrong with your manifest validation service will throw an error.
+    The validation service throws an error when something is wrong with your manifest.
 
-7. Apply your SpinnakerService
-    
+7. Apply your SpinnakerService 
+
     ```bash
     $ kubectl -n <namespace> apply -f <spinnaker service>
-    ``` 
-
+    ```


### PR DESCRIPTION
add how to migrate from halyard to operator documentation.