### PR TITLE
fix(status): Watch spinnaker service changes to update status

### DIFF
--- a/halyard-version
+++ b/halyard-version
@@ -1,1 +1,1 @@
-operator-0.4.x
+operator-75233080

--- a/pkg/controller/spinnakerservice/spinnakerservice_controller.go
+++ b/pkg/controller/spinnakerservice/spinnakerservice_controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/armory/spinnaker-operator/pkg/secrets"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -68,7 +69,14 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for potential object owned by SpinnakerService
-	return c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
+	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    TypesFactory.NewService(),
+	})
+	if err != nil {
+		return err
+	}
+	return c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    TypesFactory.NewService(),
 	})


### PR DESCRIPTION
Sometimes, if the service load balancers don't get assigned a public IP before all spinnaker pods are up and running, after load balancers are ready there's no reconciliation loop, causing that commands like
```
kubectl describe spinsvc <spinnaker>
```
To don't report UI and API urls.

Updated Halyard version fixes a race condition where parsing the BOM file sometimes failed when using one operator to deploy multiple spinnakers at the same time.