### PR TITLE
fix(validation): Default freq for kubernetes validation

### DIFF
--- a/build-tools/deployment-reverseproxy.yml
+++ b/build-tools/deployment-reverseproxy.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/integration_tests/testdata/spinnaker/overlay_validations/kustomization.yml
+++ b/integration_tests/testdata/spinnaker/overlay_validations/kustomization.yml
@@ -1,0 +1,5 @@
+bases:
+  - ../base
+
+patchesStrategicMerge:
+  - spinnakerservice-generated.yml

--- a/integration_tests/testdata/spinnaker/overlay_validations/spinnakerservice-template.yml
+++ b/integration_tests/testdata/spinnaker/overlay_validations/spinnakerservice-template.yml
@@ -1,0 +1,61 @@
+apiVersion: spinnaker.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  validation:
+    providers:
+      kubernetes:
+        enabled: {{.KubernetesEnabled}}
+      docker:
+        enabled: {{.DockerEnabled}}
+    persistentStorage:
+      s3:
+        enabled: {{.PersistentS3Enabled}}
+  spinnakerConfig:
+    config:
+      persistentStorage:
+        s3:
+          accessKeyId: XXX
+          secretAccessKey: XXX
+      providers:
+        kubernetes:
+          enabled: true
+          accounts:
+            - name: kube-no-sa
+              serviceAccount: true
+              requiredGroupMembership: []
+              providerVersion: V2
+              permissions: {}
+              dockerRegistries: []
+              configureImagePullSecrets: true
+              cacheThreads: 1
+              namespaces:
+                - default
+              omitNamespaces: []
+              kinds: []
+              omitKinds: []
+              customResources: []
+              cachingPolicies: []
+              oAuthScopes: []
+              onlySpinnakerManaged: false
+          primaryAccount: kube-no-sa
+        dockerRegistry:
+          enabled: true
+          accounts:
+            - name: dockerhub
+              requiredGroupMembership: []
+              providerVersion: V1
+              permissions: {}
+              address: https://fake.address
+              email: fake.email@spinnaker.io
+              cacheIntervalSeconds: 30
+              clientTimeoutMillis: 60000
+              cacheThreads: 1
+              paginateSize: 100
+              sortTagsByDate: false
+              trackDigests: false
+              insecureRegistry: false
+              repositories:
+                - library/nginx
+          primaryAccount: dockerhub

--- a/pkg/accounts/kubernetes/kubernetes.go
+++ b/pkg/accounts/kubernetes/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/armory/spinnaker-operator/pkg/accounts/account"
 	"github.com/armory/spinnaker-operator/pkg/apis/spinnaker/interfaces"
+	"strings"
 )
 
 // Kubernetes accounts have a deeper integration than other accounts.
@@ -44,8 +45,10 @@ func (k *AccountType) newAccount() *Account {
 
 func (k *AccountType) GetValidationSettings(spinsvc interfaces.SpinnakerService) *interfaces.ValidationSetting {
 	v := spinsvc.GetSpinnakerValidation()
-	if s, ok := v.Providers[string(interfaces.KubernetesAccountType)]; ok {
-		return &s
+	for n, s := range v.Providers {
+		if strings.ToLower(n) == strings.ToLower(string(interfaces.KubernetesAccountType)) {
+			return &s
+		}
 	}
 	return v.GetValidationSettings()
 }

--- a/pkg/apis/spinnaker/interfaces/validation_test.go
+++ b/pkg/apis/spinnaker/interfaces/validation_test.go
@@ -22,7 +22,7 @@ func TestNeedsValidation(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "when no frequency skip validation",
+			name:     "when no frequency use default frequency",
 			time:     time.Now(),
 			seconds:  0,
 			expected: false,

--- a/pkg/controller/spinnakerservice/status.go
+++ b/pkg/controller/spinnakerservice/status.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/armory/spinnaker-operator/pkg/apis/spinnaker/interfaces"
 	"github.com/go-logr/logr"
-	appsv1 "k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"

--- a/pkg/controller/webhook/tls.go
+++ b/pkg/controller/webhook/tls.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
@@ -43,31 +42,10 @@ func getCertContext(operatorNamespace string, operatorServiceName string) (*cert
 	if err != nil && !os.IsExist(err) {
 		return nil, err
 	}
-	_, err = os.Stat(filepath.Join(CertsDir, caName))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return createCerts(operatorNamespace, operatorServiceName)
-		} else {
-			return nil, fmt.Errorf("error trying to load %s: %s", caName, err.Error())
-		}
-	}
-	_, err = os.Stat(filepath.Join(CertsDir, certName))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return createCerts(operatorNamespace, operatorServiceName)
-		} else {
-			return nil, fmt.Errorf("error trying to load %s: %s", certName, err.Error())
-		}
-	}
-	_, err = os.Stat(filepath.Join(CertsDir, keyName))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return createCerts(operatorNamespace, operatorServiceName)
-		} else {
-			return nil, fmt.Errorf("error trying to load %s: %s", keyName, err.Error())
-		}
-	}
-	return loadCerts(CertsDir)
+	_ = os.Remove(filepath.Join(CertsDir, caName))
+	_ = os.Remove(filepath.Join(CertsDir, certName))
+	_ = os.Remove(filepath.Join(CertsDir, keyName))
+	return createCerts(operatorNamespace, operatorServiceName)
 }
 
 func createCerts(operatorNamespace string, operatorServiceName string) (*certContext, error) {
@@ -111,27 +89,6 @@ func createCerts(operatorNamespace string, operatorServiceName string) (*certCon
 		key:         privateKeyPEM,
 		signingCert: encodeCertPEM(signingCert),
 		certDir:     CertsDir,
-	}, nil
-}
-
-func loadCerts(certDir string) (*certContext, error) {
-	caBytes, err := ioutil.ReadFile(filepath.Join(certDir, caName))
-	if err != nil {
-		return nil, err
-	}
-	certBytes, err := ioutil.ReadFile(filepath.Join(certDir, certName))
-	if err != nil {
-		return nil, err
-	}
-	keyBytes, err := ioutil.ReadFile(filepath.Join(certDir, keyName))
-	if err != nil {
-		return nil, err
-	}
-	return &certContext{
-		cert:        certBytes,
-		key:         keyBytes,
-		signingCert: caBytes,
-		certDir:     certDir,
 	}, nil
 }
 

--- a/pkg/deploy/spindeploy/transformer/defaults.go
+++ b/pkg/deploy/spindeploy/transformer/defaults.go
@@ -59,7 +59,7 @@ func (a *defaultsTransformer) setArchaiusDefaultsForProfile(profile interfaces.F
 		archaius := map[string]interface{}{}
 		archaius["enabled"] = false
 		profile["archaius"] = archaius
-		a.log.Info("Archaius defaults: applied", "profileName", profileName)
+		a.log.V(10).Info("Archaius defaults: applied", "profileName", profileName)
 		return nil // Created new map and saved into profile
 	}
 	archaius, ok := archaius_.(map[string]interface{})
@@ -73,7 +73,7 @@ func (a *defaultsTransformer) setArchaiusDefaultsForProfile(profile interfaces.F
 		return nil
 	}
 	archaius["enabled"] = false
-	a.log.Info("Archaius defaults: applied", "profileName", profileName)
+	a.log.V(10).Info("Archaius defaults: applied", "profileName", profileName)
 	return nil
 }
 


### PR DESCRIPTION
Small fixes:
* When specifying a `spec.validation.kubernetes` block, validations were always skipped if no frequency was given. Now a default internal value of 30 seconds is used if no frequency is given
* Development reverse proxy failed to deploy on latest Kubernetes (`Deployment` version `extensions/v1beta1` vs `apps/v1`)
* Ignore case when looking for `spec.validation.kubernetes` vs `spec.validation.Kubernetes`
* Status was not correctly updated on latest Kubernetes versions (listing deployments version `extensions/v1beta1` vs `apps/v1`)
* Always generate TLS certificates on startup even if there are some already there. Helps with problems of wrong certificates present when operator is moved to another namespace


Also added integration tests for some validation settings.