### PR TITLE
feat(errors): Better error messages and events reported

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,10 +109,12 @@ jobs:
         if: steps.build_type.outputs.build_type == 'rc' || steps.build_type.outputs.build_type == 'release'
         run: |
           branch=$(git rev-parse --abbrev-ref HEAD)
+          sha=${{ github.sha }}
           if [[ ${{github.event_name }} = "pull_request" ]] ; then branch=${{ github.head_ref }} ; fi
+          if [[ ${{github.event_name }} = "pull_request" ]] ; then sha=${{ github.event.pull_request.head.sha }} ; fi
           halyard=$(cat halyard-version | head -1)
           curl -H "Content-Type: application/json" \
-              -d "{\"secret\": \"${{ secrets.SPINNAKER_TOKEN }}\", \"parameters\": { \"OPERATOR_IMAGE\": \"${{ steps.build_type.outputs.registry }}/armory/spinnaker-operator:${{ steps.build_type.outputs.version }}\", \"HALYARD_IMAGE\": \"armory/halyard:$halyard\", \"TESTS_BRANCH\": \"$branch\" } }" \
+              -d "{\"secret\": \"${{ secrets.SPINNAKER_TOKEN }}\", \"parameters\": { \"OPERATOR_IMAGE\": \"${{ steps.build_type.outputs.registry }}/armory/spinnaker-operator:${{ steps.build_type.outputs.version }}\", \"HALYARD_IMAGE\": \"armory/halyard:$halyard\", \"TESTS_BRANCH\": \"$branch\", \"COMMIT_SHA\": \"$sha\" } }" \
               -X POST https://spinnaker-api.armory.io/webhooks/webhook/operator-int-tests
 
       - name: Create Release

--- a/build-tools/version.sh
+++ b/build-tools/version.sh
@@ -29,6 +29,7 @@ case $BRANCH in
 esac
 
 read -r major minor patch rc <<< "${v//./ }" && patch=$(echo "$patch" | sed 's|[^0-9]*||g')
+[[ "x$(git tag -l "v$major.$minor.$patch")" != "x" ]] && rc=""
 
 case $VERSION_TYPE in
     snapshot)

--- a/pkg/controller/spinnakervalidating/spinnakervalidating_controller.go
+++ b/pkg/controller/spinnakervalidating/spinnakervalidating_controller.go
@@ -78,7 +78,7 @@ func (v *spinnakerValidatingController) Handle(ctx context.Context, req admissio
 		errorMsg := validationResult.GetErrorMessage()
 		err := fmt.Errorf(errorMsg)
 		log.Error(err, errorMsg, "metadata.name", svc)
-		return admission.Errored(http.StatusBadRequest, err)
+		return admission.Denied(errorMsg)
 	}
 	// Update the status with any admission status change, only if there's already an existing SpinnakerService
 	if req.AdmissionRequest.Operation == v1beta1.Update {

--- a/pkg/deploy/spindeploy/changedetector/common_test.go
+++ b/pkg/deploy/spindeploy/changedetector/common_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/armory/spinnaker-operator/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"testing"
 )
@@ -19,7 +20,7 @@ var th = testHelpers{
 
 func (th *testHelpers) setupChangeDetector(generator Generator, t *testing.T, objs ...runtime.Object) ChangeDetector {
 	fakeClient := test.FakeClient(t, objs...)
-	ch, err := generator.NewChangeDetector(fakeClient, log.Log.WithName("spinnakerservice"))
+	ch, err := generator.NewChangeDetector(fakeClient, log.Log.WithName("spinnakerservice"), &record.FakeRecorder{})
 	assert.Nil(t, err)
 	return ch
 }

--- a/pkg/deploy/spindeploy/changedetector/config.go
+++ b/pkg/deploy/spindeploy/changedetector/config.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"github.com/armory/spinnaker-operator/pkg/apis/spinnaker/interfaces"
 	"github.com/go-logr/logr"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 )
@@ -15,13 +16,14 @@ const SpinnakerConfigHashKey = "config"
 const KustomizeHashKey = "kustomize"
 
 type configChangeDetector struct {
-	log logr.Logger
+	log         logr.Logger
+	evtRecorder record.EventRecorder
 }
 
 type configChangeDetectorGenerator struct{}
 
-func (g *configChangeDetectorGenerator) NewChangeDetector(client client.Client, log logr.Logger) (ChangeDetector, error) {
-	return &configChangeDetector{log}, nil
+func (g *configChangeDetectorGenerator) NewChangeDetector(client client.Client, log logr.Logger, evtRecorder record.EventRecorder) (ChangeDetector, error) {
+	return &configChangeDetector{log: log, evtRecorder: evtRecorder}, nil
 }
 
 // IsSpinnakerUpToDate returns true if the Config has changed compared to the last recorded status hash

--- a/pkg/deploy/spindeploy/changedetector/expose_lb.go
+++ b/pkg/deploy/spindeploy/changedetector/expose_lb.go
@@ -7,21 +7,23 @@ import (
 	"github.com/armory/spinnaker-operator/pkg/util"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 )
 
 type exposeLbChangeDetector struct {
-	client client.Client
-	log    logr.Logger
+	client      client.Client
+	log         logr.Logger
+	evtRecorder record.EventRecorder
 }
 
 type exposeLbChangeDetectorGenerator struct {
 }
 
-func (g *exposeLbChangeDetectorGenerator) NewChangeDetector(client client.Client, log logr.Logger) (ChangeDetector, error) {
-	return &exposeLbChangeDetector{client: client, log: log}, nil
+func (g *exposeLbChangeDetectorGenerator) NewChangeDetector(client client.Client, log logr.Logger, evtRecorder record.EventRecorder) (ChangeDetector, error) {
+	return &exposeLbChangeDetector{client: client, log: log, evtRecorder: evtRecorder}, nil
 }
 
 // IsSpinnakerUpToDate returns true if expose spinnaker configuration matches actual exposed services

--- a/pkg/deploy/spindeploy/changedetector/x509.go
+++ b/pkg/deploy/spindeploy/changedetector/x509.go
@@ -7,20 +7,22 @@ import (
 	"github.com/armory/spinnaker-operator/pkg/util"
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strconv"
 )
 
 type x509ChangeDetector struct {
-	client client.Client
-	log    logr.Logger
+	client      client.Client
+	log         logr.Logger
+	evtRecorder record.EventRecorder
 }
 
 type x509ChangeDetectorGenerator struct {
 }
 
-func (g *x509ChangeDetectorGenerator) NewChangeDetector(client client.Client, log logr.Logger) (ChangeDetector, error) {
-	return &x509ChangeDetector{client: client, log: log}, nil
+func (g *x509ChangeDetectorGenerator) NewChangeDetector(client client.Client, log logr.Logger, evtRecorder record.EventRecorder) (ChangeDetector, error) {
+	return &x509ChangeDetector{client: client, log: log, evtRecorder: evtRecorder}, nil
 }
 
 // IsSpinnakerUpToDate returns true if there is a x509 configuration with a matching service

--- a/pkg/halyard/validate.go
+++ b/pkg/halyard/validate.go
@@ -49,7 +49,7 @@ func (s *Service) buildValidationRequest(ctx context.Context, spinsvc interfaces
 	// This will also serve as a secret validation step
 	sanitizedCfg, err := sanitizeSecrets(ctx, cfg.Config)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error decrypting secrets in config:\n  %w", err)
 	}
 
 	if err := s.addObjectToRequest(writer, "config", sanitizedCfg); err != nil {
@@ -103,7 +103,11 @@ func sanitizeSecrets(ctx context.Context, object interface{}) (interface{}, erro
 			if err == nil && f {
 				s = path.Join(SecretRelativeFilenames, path.Base(s))
 			}
-			return s, err
+			if err == nil {
+				return s, nil
+			} else {
+				return s, fmt.Errorf("Error decrypting secret for value '%s':\n  %w", val, err)
+			}
 		}
 		return val, nil
 	}

--- a/pkg/halyard/validate_test.go
+++ b/pkg/halyard/validate_test.go
@@ -106,7 +106,7 @@ spec:
 	// Validation fails on a non initialized secret context
 	_, err = h.buildValidationRequest(context.TODO(), spinsvc, true)
 	if assert.NotNil(t, err) {
-		assert.Equal(t, "secret context not initialized", err.Error())
+		assert.True(t, strings.Contains(err.Error(), "secret context not initialized"))
 	}
 
 	ctx := secrets.NewContext(context.TODO(), nil, "ns")

--- a/pkg/secrets/kubernetes.go
+++ b/pkg/secrets/kubernetes.go
@@ -33,11 +33,11 @@ func NewKubernetesSecretDecrypter(ctx context.Context, isFile bool, params strin
 func (k *KubernetesDecrypter) Decrypt() (string, error) {
 	client, err := corev1.NewForConfig(k.restConfig)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Error creating kubernetes client:\n  %w", err)
 	}
 	sec, err := client.Secrets(k.namespace).Get(k.name, metav1.GetOptions{})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Error reading secret with name '%s' from kubernetes:\n  %w", k.name, err)
 	}
 	if d, ok := sec.Data[k.key]; ok {
 		if k.isFile {
@@ -45,7 +45,7 @@ func (k *KubernetesDecrypter) Decrypt() (string, error) {
 		}
 		return string(d), nil
 	}
-	return "", fmt.Errorf("cannot find key %s in secret %s", k.key, k.name)
+	return "", fmt.Errorf("Cannot find key %s in secret %s", k.key, k.name)
 }
 
 func (s *KubernetesDecrypter) IsFile() bool {
@@ -53,7 +53,9 @@ func (s *KubernetesDecrypter) IsFile() bool {
 }
 
 func (k *KubernetesDecrypter) parse(params string) error {
-	_, _, err := ParseKubernetesSecretParams(params)
+	name, key, err := ParseKubernetesSecretParams(params)
+	k.name = name
+	k.key = key
 	return err
 }
 
@@ -63,7 +65,7 @@ func ParseKubernetesSecretParams(params string) (string, string, error) {
 	for _, element := range tokens {
 		kv := strings.Split(element, ":")
 		if len(kv) != 2 {
-			return "", "", fmt.Errorf("secret format error - 'n' for name is required, 'k' for secret key is required - got '%s'", element)
+			return "", "", fmt.Errorf("Secret format error - 'n' for name is required, 'k' for secret key is required - got '%s'", element)
 		}
 
 		switch kv[0] {
@@ -75,10 +77,10 @@ func ParseKubernetesSecretParams(params string) (string, string, error) {
 	}
 
 	if name == "" {
-		return "", "", fmt.Errorf("secret format error - 'n' for name is required")
+		return "", "", fmt.Errorf("Secret format error - 'n' for name is required")
 	}
 	if key == "" {
-		return "", "", fmt.Errorf("secret format error - 'k' for secret key is required")
+		return "", "", fmt.Errorf("Secret format error - 'k' for secret key is required")
 	}
 	return name, key, nil
 }

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"fmt"
 	"github.com/armory/go-yaml-tools/pkg/secrets"
 	"os"
 )
@@ -19,13 +20,13 @@ func Decode(ctx context.Context, val string) (string, bool, error) {
 	// Get decrypter
 	dec, err := secrets.NewDecrypter(ctx, val)
 	if err != nil {
-		return val, false, err
+		return val, false, fmt.Errorf("Error creating decrypter for value '%s':\n  %w", val, err)
 	}
 
 	var v string
 	c, err := FromContextWithError(ctx)
 	if err != nil {
-		return "", false, err
+		return "", false, fmt.Errorf("Error creating secret context for value '%s':\n  %w", val, err)
 	}
 
 	// Check if in cache
@@ -40,7 +41,7 @@ func Decode(ctx context.Context, val string) (string, bool, error) {
 
 	v, err = dec.Decrypt()
 	if err != nil {
-		return "", false, err
+		return "", false, fmt.Errorf("Error decrypting secret value '%s':\n  %w", val, err)
 	}
 
 	// If we could get the cache, update it

--- a/pkg/validate/accounts.go
+++ b/pkg/validate/accounts.go
@@ -91,7 +91,7 @@ func getAccountsFromConfig(ctx context.Context, spinSvc interfaces.SpinnakerServ
 func (a *accountValidator) Validate(spinSvc interfaces.SpinnakerService, options Options) ValidationResult {
 	err := a.v.Validate(spinSvc, options.Client, options.Ctx, options.Log.WithValues("Accounts.Name", a.name))
 	if err != nil {
-		return NewResultFromError(err, a.fatal)
+		return NewResultFromError(fmt.Errorf("Validator for account '%s' detected an error:\n  %w", a.name, err), a.fatal)
 	}
 	return ValidationResult{}
 }

--- a/pkg/validate/hal_validation.go
+++ b/pkg/validate/hal_validation.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"fmt"
 	"github.com/armory/spinnaker-operator/pkg/apis/spinnaker/interfaces"
 )
 
@@ -9,7 +10,7 @@ type halValidator struct{}
 func (h *halValidator) Validate(spinSvc interfaces.SpinnakerService, options Options) ValidationResult {
 	err := options.Halyard.Validate(options.Ctx, spinSvc, false, options.Log)
 	if err != nil {
-		return NewResultFromError(err, true)
+		return NewResultFromError(fmt.Errorf("Halyard validator detected an error:\n  %w", err), true)
 	}
 	return ValidationResult{}
 }

--- a/pkg/validate/single_namespace.go
+++ b/pkg/validate/single_namespace.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"errors"
+	"fmt"
 	"github.com/armory/spinnaker-operator/pkg/apis/spinnaker/interfaces"
 	"k8s.io/api/admission/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -14,7 +15,7 @@ func (v *singleNamespaceValidator) Validate(spinSvc interfaces.SpinnakerService,
 		// Make sure that'v the only SpinnakerService
 		ss := opts.TypesFactory.NewServiceList()
 		if err := opts.Client.List(opts.Ctx, ss, client.InNamespace(spinSvc.GetNamespace())); err != nil {
-			return NewResultFromError(err, true)
+			return NewResultFromError(fmt.Errorf("Single namespace validator detected an error:\n  %w", err), true)
 		}
 		if len(ss.GetItems()) > 0 {
 			return NewResultFromError(errors.New("SpinnakerService must be unique per namespace"), true)

--- a/pkg/validate/version.go
+++ b/pkg/validate/version.go
@@ -12,20 +12,20 @@ func (v *versionValidator) Validate(spinSvc interfaces.SpinnakerService, options
 	config := spinSvc.GetSpinnakerConfig()
 	version, err := config.GetHalConfigPropString(options.Ctx, "version")
 	if err != nil {
-		return NewResultFromError(fmt.Errorf("unable to read spinnaker version from manifest: %s", err.Error()), true)
+		return NewResultFromError(fmt.Errorf("Unable to read spinnaker version from manifest:\n  %w", err), true)
 	}
 	_, err = options.Halyard.GetBOM(options.Ctx, version)
 	if err != nil {
-		return v.handleBOMError(options, err)
+		return v.handleBOMError(version, options, err)
 	}
 	return ValidationResult{}
 }
 
-func (v *versionValidator) handleBOMError(opts Options, err error) ValidationResult {
+func (v *versionValidator) handleBOMError(version string, opts Options, err error) ValidationResult {
 	all, errAll := opts.Halyard.GetAllVersions(opts.Ctx)
 	if errAll != nil {
-		return NewResultFromError(err, false)
+		return NewResultFromError(fmt.Errorf("Error reading BOM for version %s: %w, and unable to list available versions: %s", version, err, errAll.Error()), false)
 	}
-	newErr := fmt.Errorf("%s.\nLatest stable versions: [%s]", err.Error(), strings.Join(all, ", "))
+	newErr := fmt.Errorf("Error reading BOM for version %s: %w.\nLatest stable versions: [%s]", version, err, strings.Join(all, ", "))
 	return NewResultFromError(newErr, false)
 }


### PR DESCRIPTION
* Don't print full json message on `kubectl apply -f` errors, just the human friendly error message
* Report errors during reconciler process on `kubectl describe spinsvc <name>`
* Fixed bug on kubernetes secrets decrypter
* Fixed bug on version script to step to next minor version after a release