### PR TITLE
feat(settings): Global service-settings

### DIFF
--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -14,7 +14,7 @@ var defaults Defaults
 
 func init() {
 	defaults = Defaults{
-		OperatorImageDefault:  "docker.io/germanarmory/spinnaker-operator:1.0.0-snapshot.uncommitted.feat.global.service.settings.7de7938-2",
+		OperatorImageDefault:  "armory/spinnaker-operator:dev",
 		HalyardImageDefault:   "armory/halyard:operator-dev",
 		BucketDefault:         "operator-int-tests",
 		BucketRegionDefault:   "us-west-2",

--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -14,7 +14,7 @@ var defaults Defaults
 
 func init() {
 	defaults = Defaults{
-		OperatorImageDefault:  "armory/spinnaker-operator:dev",
+		OperatorImageDefault:  "docker.io/germanarmory/spinnaker-operator:1.0.0-snapshot.uncommitted.feat.global.service.settings.7de7938-2",
 		HalyardImageDefault:   "armory/halyard:operator-dev",
 		BucketDefault:         "operator-int-tests",
 		BucketRegionDefault:   "us-west-2",
@@ -164,7 +164,9 @@ func TestProfilesOverlay(t *testing.T) {
 	// setup
 	t.Parallel()
 	LogMainStep(t, `Test goals:
-- Settings in profile configs should work `)
+- Settings in profile configs should work 
+- service-settings are merged and applied
+`)
 
 	spinOverlay := "testdata/spinnaker/overlay_profiles"
 	ns := RandomString("spin-profiles-test")
@@ -198,6 +200,18 @@ func TestProfilesOverlay(t *testing.T) {
 	assert.Equal(t,
 		`#!/bin/bash -e
 echo "hello world!"`, sh)
+	// all services have the global var
+	for _, svc := range []string{"clouddriver", "echo", "front50", "gate", "orca", "rosco"} {
+		pod := GetPodName(ns, svc, e, t)
+		c := fmt.Sprintf("%s -n %s get pod %s -o=jsonpath='{.spec.containers[0].env[?(@.name==\"GLOBAL_VAR\")]}'", e.KubectlPrefix(), ns, pod)
+		o := RunCommandSilentAndAssert(c, t)
+		assert.NotEqual(t, "", strings.TrimSpace(o))
+	}
+	// only clouddriver has the extra var
+	pod := GetPodName(ns, "clouddriver", e, t)
+	c := fmt.Sprintf("%s -n %s get pod %s -o=jsonpath='{.spec.containers[0].env[?(@.name==\"SVC_NAME\")]}'", e.KubectlPrefix(), ns, pod)
+	o = RunCommandSilentAndAssert(c, t)
+	assert.NotEqual(t, "", strings.TrimSpace(o))
 }
 
 func TestValidations(t *testing.T) {

--- a/integration_tests/testdata/spinnaker/overlay_profiles/spinnakerservice.yml
+++ b/integration_tests/testdata/spinnaker/overlay_profiles/spinnakerservice.yml
@@ -40,7 +40,13 @@ spec:
       profiles__rosco__packer__my_custom_script.sh: |
         #!/bin/bash -e
         echo "hello world!"
+
     service-settings:
       clouddriver:
+        env:
+          SVC_NAME: clouddriver
         kubernetes:
           serviceAccountName: spin-sa
+      spinnaker:
+        env:
+          GLOBAL_VAR: global

--- a/pkg/deploy/spindeploy/transformer/spinsvcsettings.go
+++ b/pkg/deploy/spindeploy/transformer/spinsvcsettings.go
@@ -1,0 +1,76 @@
+package transformer
+
+import (
+	"context"
+	"fmt"
+	"github.com/armory/spinnaker-operator/pkg/apis/spinnaker/interfaces"
+	"github.com/armory/spinnaker-operator/pkg/bom"
+	"github.com/armory/spinnaker-operator/pkg/inspect"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// defaultsTransformer inserts default values to *-local profile to each service
+type spinSvcSettingsTransformer struct {
+	*DefaultTransformer
+	svc    interfaces.SpinnakerService
+	log    logr.Logger
+	client client.Client
+}
+
+type spinSvcSettingsTransformerGenerator struct{}
+
+func (g *spinSvcSettingsTransformerGenerator) GetName() string {
+	return "Global spinnaker service-settings"
+}
+
+func (g *spinSvcSettingsTransformerGenerator) NewTransformer(
+	svc interfaces.SpinnakerService,
+	client client.Client,
+	log logr.Logger) (Transformer, error) {
+	base := &DefaultTransformer{}
+	tr := spinSvcSettingsTransformer{svc: svc, log: log, client: client, DefaultTransformer: base}
+	base.ChildTransformer = &tr
+	return &tr, nil
+}
+
+func (t *spinSvcSettingsTransformer) TransformConfig(ctx context.Context) error {
+	g := t.getGlobalSpinSvcSettings()
+	if g == nil {
+		return nil
+	}
+	for _, s := range bom.Services {
+		if s.Name == "deck" {
+			continue
+		}
+		err := t.addServiceSettings(s.Name, g)
+		if err != nil {
+			return fmt.Errorf("Error adding global spinnaker service-settings to service \"%s\":\n  %w", s.Name, err)
+		}
+	}
+	return nil
+}
+
+func (t *spinSvcSettingsTransformer) getGlobalSpinSvcSettings() interfaces.FreeForm {
+	for k, v := range t.svc.GetSpinnakerConfig().ServiceSettings {
+		if k == "spinnaker" {
+			return v
+		}
+	}
+	return nil
+}
+
+func (t *spinSvcSettingsTransformer) addServiceSettings(svcName string, s interfaces.FreeForm) error {
+	var existing interfaces.FreeForm
+	for k, v := range t.svc.GetSpinnakerConfig().ServiceSettings {
+		if k == svcName {
+			existing = v
+		}
+	}
+	if existing == nil {
+		existing = interfaces.FreeForm{}
+	}
+	merged := inspect.Merge(s, existing)
+	t.svc.GetSpinnakerConfig().ServiceSettings[svcName] = merged
+	return nil
+}

--- a/pkg/deploy/spindeploy/transformer/spinsvcsettings_test.go
+++ b/pkg/deploy/spindeploy/transformer/spinsvcsettings_test.go
@@ -1,0 +1,108 @@
+package transformer
+
+import (
+	"context"
+	"fmt"
+	"github.com/armory/spinnaker-operator/pkg/inspect"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGlobalServiceSettings(t *testing.T) {
+	tests := []struct {
+		name                 string
+		svcName              string
+		ss                   string
+		expectedGlobalProps  map[string]string
+		expectedServiceProps map[string]string
+	}{
+		{
+			name:    "no service specific config",
+			svcName: "",
+			ss: `
+    service-settings:
+      spinnaker:
+        env:
+          JAVA_OPTS: -Djdk.tls.client.protocols=TLSv1.2
+`,
+			expectedGlobalProps: map[string]string{
+				"env.JAVA_OPTS": "-Djdk.tls.client.protocols=TLSv1.2",
+			},
+			expectedServiceProps: nil,
+		},
+		{
+			name:    "existing service specific config",
+			svcName: "gate",
+			ss: `
+    service-settings:
+      gate:
+        artifactId: xxx
+      spinnaker:
+        env:
+          JAVA_OPTS: -Djdk.tls.client.protocols=TLSv1.2
+`,
+			expectedGlobalProps: map[string]string{
+				"env.JAVA_OPTS": "-Djdk.tls.client.protocols=TLSv1.2",
+			},
+			expectedServiceProps: map[string]string{
+				"artifactId":    "xxx",
+				"env.JAVA_OPTS": "-Djdk.tls.client.protocols=TLSv1.2",
+			},
+		},
+		{
+			name:    "merged service settings",
+			svcName: "gate",
+			ss: `
+    service-settings:
+      gate:
+        env:
+          VAULT_TOKEN: xxx
+      spinnaker:
+        env:
+          JAVA_OPTS: -Djdk.tls.client.protocols=TLSv1.2
+`,
+			expectedGlobalProps: map[string]string{
+				"env.JAVA_OPTS": "-Djdk.tls.client.protocols=TLSv1.2",
+			},
+			expectedServiceProps: map[string]string{
+				"env.VAULT_TOKEN": "xxx",
+				"env.JAVA_OPTS":   "-Djdk.tls.client.protocols=TLSv1.2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := `
+apiVersion: spinnaker.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+  namespace: ns1
+spec:
+  spinnakerConfig:
+%s
+`
+			s = fmt.Sprintf(s, tt.ss)
+			tr, spinSvc := th.setupTransformerFromSpinText(&spinSvcSettingsTransformerGenerator{}, s, t)
+			err := tr.TransformConfig(context.TODO())
+			assert.Nil(t, err)
+			for _, svc := range []string{"gate", "orca", "clouddriver", "rosco", "front50", "echo", "igor"} {
+				ss := spinSvc.GetSpinnakerConfig().ServiceSettings[svc]
+				assert.NotNil(t, ss)
+				for k, v := range tt.expectedGlobalProps {
+					a, err := inspect.GetRawObjectPropString(ss, k)
+					assert.Nil(t, err)
+					assert.Equal(t, v, a)
+				}
+				if tt.svcName == svc {
+					for k, v := range tt.expectedServiceProps {
+						a, err := inspect.GetRawObjectPropString(ss, k)
+						assert.Nil(t, err)
+						assert.Equal(t, v, a)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/deploy/spindeploy/transformer/transformer.go
+++ b/pkg/deploy/spindeploy/transformer/transformer.go
@@ -18,7 +18,7 @@ func init() {
 	Generators = append(Generators, &ownerTransformerGenerator{}, &targetTransformerGenerator{},
 		&exposeLbTransformerGenerator{}, &serverPortTransformerGenerator{}, &x509TransformerGenerator{},
 		&accountsTransformerGenerator{}, &secretsTransformerGenerator{}, &statsTransformerGenerator{},
-		&patchTransformerGenerator{}, &defaultsTransformerGenerator{})
+		&patchTransformerGenerator{}, &defaultsTransformerGenerator{}, &spinSvcSettingsTransformerGenerator{})
 }
 
 // Transformer affects how Spinnaker is deployed.

--- a/pkg/inspect/parse_test.go
+++ b/pkg/inspect/parse_test.go
@@ -120,3 +120,88 @@ func TestSanitizeSecrets(t *testing.T) {
 		assert.Equal(t, "inspected-sval2", ttr.SArray[1])
 	}
 }
+
+func TestMerge(t *testing.T) {
+	tests := []struct {
+		name   string
+		a      map[string]interface{}
+		b      map[string]interface{}
+		result map[string]interface{}
+	}{
+		{
+			name: "two different maps",
+			a: map[string]interface{}{
+				"env": map[string]interface{}{
+					"JAVA_OPTS": "-Dxxx",
+				},
+			},
+			b: map[string]interface{}{
+				"artifactId": "yyy",
+			},
+			result: map[string]interface{}{
+				"env": map[string]interface{}{
+					"JAVA_OPTS": "-Dxxx",
+				},
+				"artifactId": "yyy",
+			},
+		},
+		{
+			name: "same root key in maps",
+			a: map[string]interface{}{
+				"env": map[string]interface{}{
+					"JAVA_OPTS": "-Dxxx",
+				},
+			},
+			b: map[string]interface{}{
+				"env": map[string]interface{}{
+					"AWS_ACCESS_KEY": "abcd",
+				},
+			},
+			result: map[string]interface{}{
+				"env": map[string]interface{}{
+					"JAVA_OPTS":      "-Dxxx",
+					"AWS_ACCESS_KEY": "abcd",
+				},
+			},
+		},
+		{
+			name: "arrays",
+			a: map[string]interface{}{
+				"kubernetes": map[string]interface{}{
+					"volumes": []struct {
+						id    string
+						vType string
+					}{
+						{id: "1", vType: "1t"},
+					},
+				},
+			},
+			b: map[string]interface{}{
+				"kubernetes": map[string]interface{}{
+					"volumes": []struct {
+						id    string
+						vType string
+					}{
+						{id: "2", vType: "2t"},
+					},
+				},
+			},
+			result: map[string]interface{}{
+				"kubernetes": map[string]interface{}{
+					"volumes": []struct {
+						id    string
+						vType string
+					}{
+						{id: "1", vType: "1t"},
+						{id: "2", vType: "2t"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		r := Merge(tt.a, tt.b)
+		assert.Equal(t, tt.result, r)
+	}
+}


### PR DESCRIPTION
New:

`service-settings` with key `spinnaker` will be applied to all spinnaker services (except deck):
```
    service-settings:
      spinnaker:
        env:
          GLOBAL_VAR: global
```