### PR TITLE
fix(validation): Add parallel validation support

### DIFF
--- a/pkg/validate/parallel.go
+++ b/pkg/validate/parallel.go
@@ -1,8 +1,10 @@
 package validate
 
 import (
+	"context"
 	"fmt"
 	"github.com/armory/spinnaker-operator/pkg/apis/spinnaker/interfaces"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type ParallelValidator struct {
@@ -11,15 +13,48 @@ type ParallelValidator struct {
 
 func (p *ParallelValidator) Validate(spinSvc interfaces.SpinnakerService, options Options) ValidationResult {
 	var result ValidationResult
+
+	valGrp := wait.Group{}
+	ctx, cancel := context.WithCancel(options.Ctx)
+	// Replace context
+	options.Ctx = ctx
+	resCh := make(chan ValidationResult)
+	doneCh := make(chan struct{})
+
 	for _, v := range p.runInParallel {
-		options.Log.Info(fmt.Sprintf("Running validator %T", v))
-		result.Merge(v.Validate(spinSvc, options))
-		if result.HasFatalErrors() {
-			options.Log.Info(fmt.Sprintf("Validator %T detected a fatal error, aborting", v))
+		func(v SpinnakerValidator) {
+			valGrp.StartWithContext(ctx, func(ctx context.Context) {
+				options.Log.Info(fmt.Sprintf("Running validator %T", v))
+				res := v.Validate(spinSvc, options)
+				resCh <- res
+				if res.HasFatalErrors() {
+					options.Log.Info(fmt.Sprintf("Validator %T detected a fatal error", v))
+				}
+			})
+		}(v)
+	}
+
+	// Close the result channel once all executions have been executed or the context has been canceled
+	go func() {
+		valGrp.Wait()
+		close(doneCh)
+	}()
+
+	for {
+		select {
+		case <-doneCh:
 			return result
+		case res := <-resCh:
+			result.Merge(res)
+			// Cancel the context if a fatal error is detected
+			// This will effectively abort the validation AS LONG AS the validation
+			// correctly uses the context.
+			if res.HasFatalErrors() && spinSvc.GetSpinnakerValidation().FailFast {
+				cancel()
+			}
 		}
 	}
-	return result
+	//return result
 }
 
 func (p *ParallelValidator) validateAccountsInParallel(accounts []Account, options Options, f func(Account, Options) ValidationResult) ValidationResult {

--- a/pkg/validate/parallel_test.go
+++ b/pkg/validate/parallel_test.go
@@ -1,0 +1,132 @@
+package validate
+
+import (
+	"context"
+	"errors"
+	"github.com/armory/spinnaker-operator/pkg/apis/spinnaker/interfaces"
+	"github.com/armory/spinnaker-operator/pkg/apis/spinnaker/v1alpha2"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"testing"
+	"time"
+)
+
+type timedValidator struct {
+	duration time.Duration
+	res      ValidationResult
+}
+
+func (t *timedValidator) Validate(spinSvc interfaces.SpinnakerService, options Options) ValidationResult {
+	for {
+		select {
+		case <-options.Ctx.Done():
+			return t.res
+		case <-time.After(t.duration):
+			return t.res
+		}
+	}
+}
+
+func TestParallel(t *testing.T) {
+	cases := []struct {
+		name       string
+		failfast   bool
+		validators []SpinnakerValidator
+		check      func(t2 *testing.T, start time.Time, res ValidationResult)
+	}{
+		{
+			"single validation",
+			true,
+			[]SpinnakerValidator{
+				&timedValidator{
+					duration: 500 * time.Millisecond,
+					res:      ValidationResult{},
+				},
+			},
+			func(t *testing.T, start time.Time, res ValidationResult) {
+				assert.False(t, res.Fatal)
+				assert.Empty(t, res.Errors)
+				assert.GreaterOrEqual(t, time.Now().Sub(start).Milliseconds(), int64(500))
+			},
+		},
+		{
+			"2 validations",
+			true,
+			[]SpinnakerValidator{
+				&timedValidator{
+					duration: 500 * time.Millisecond,
+					res:      ValidationResult{},
+				},
+				&timedValidator{
+					duration: 500 * time.Millisecond,
+					res:      ValidationResult{},
+				},
+			},
+			func(t *testing.T, start time.Time, res ValidationResult) {
+				assert.False(t, res.Fatal)
+				assert.Empty(t, res.Errors)
+				d := time.Now().Sub(start).Milliseconds()
+				assert.Less(t, d, int64(520))
+				assert.GreaterOrEqual(t, d, int64(500))
+			},
+		},
+		{
+			"fail fast should stop as soon as first validation fails",
+			true,
+			[]SpinnakerValidator{
+				&timedValidator{
+					duration: 500 * time.Millisecond,
+					res:      ValidationResult{Fatal: true, Errors: []error{errors.New("error detected")}},
+				},
+				&timedValidator{
+					duration: 2 * time.Second,
+					res:      ValidationResult{},
+				},
+			},
+			func(t *testing.T, start time.Time, res ValidationResult) {
+				d := time.Now().Sub(start).Milliseconds()
+				assert.True(t, res.HasFatalErrors())
+				assert.Less(t, d, int64(520))
+				assert.GreaterOrEqual(t, d, int64(500))
+			},
+		},
+		{
+			"without fail fast, wait for all validations",
+			false,
+			[]SpinnakerValidator{
+				&timedValidator{
+					duration: 500 * time.Millisecond,
+					res:      ValidationResult{Fatal: true, Errors: []error{errors.New("error 1")}},
+				},
+				&timedValidator{
+					duration: 1 * time.Second,
+					res:      ValidationResult{},
+				},
+			},
+			func(t *testing.T, start time.Time, res ValidationResult) {
+				d := time.Now().Sub(start).Milliseconds()
+				assert.True(t, res.HasFatalErrors())
+				assert.Less(t, d, int64(1100))
+				assert.GreaterOrEqual(t, d, int64(1000))
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t2 *testing.T) {
+			now := time.Now()
+			p := ParallelValidator{runInParallel: c.validators}
+			opts := Options{
+				Ctx: context.TODO(),
+				Req: admission.Request{},
+				Log: log.NullLogger{},
+			}
+			spinsvc := &v1alpha2.SpinnakerService{}
+			spinsvc.Spec.Validation.FailFast = c.failfast
+
+			res := p.Validate(spinsvc, opts)
+			c.check(t2, now, res)
+		})
+	}
+}


### PR DESCRIPTION
Also implements `failfast` behavior as long as validation properly use the provided context.