### PR TITLE
fix(accounts): Add Spring profile on specialized services

### DIFF
--- a/pkg/deploy/spindeploy/transformer/accounts.go
+++ b/pkg/deploy/spindeploy/transformer/accounts.go
@@ -46,9 +46,12 @@ func (a *accountsTransformer) TransformManifests(ctx context.Context, gen *gener
 	}
 
 	// Enable "accounts" Spring profile for each potential service
-	for _, s := range accounts.GetAllServicesWithAccounts() {
-		if err := addSpringProfile(gen.Config[s].Deployment, s, accounts.SpringProfile); err != nil {
-			return err
+	svcs := accounts.GetAllServicesWithAccounts()
+	for k := range gen.Config {
+		if a.isServiceWithAccount(k, svcs) {
+			if err := addSpringProfile(gen.Config[k].Deployment, k, accounts.SpringProfile); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -64,6 +67,15 @@ func (a *accountsTransformer) TransformManifests(ctx context.Context, gen *gener
 	}
 	a.log.Info(fmt.Sprintf("found %d accounts to deploy", len(crdAccs)))
 	return updateServiceSettings(ctx, crdAccs, gen)
+}
+
+func (a *accountsTransformer) isServiceWithAccount(serviceKey string, accountServices []string) bool {
+	for _, s := range accountServices {
+		if util.IsServiceLike(serviceKey, s) {
+			return true
+		}
+	}
+	return false
 }
 
 func updateServiceSettings(ctx context.Context, crdAccounts []account.Account, gen *generated.SpinnakerGeneratedConfig) error {

--- a/pkg/deploy/spindeploy/transformer/accounts_test.go
+++ b/pkg/deploy/spindeploy/transformer/accounts_test.go
@@ -49,6 +49,40 @@ func TestAddSpringProfile(t *testing.T) {
 	}
 }
 
+func TestAddSpringProfileHA(t *testing.T) {
+
+	d := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "clouddriver-ro",
+							Env: []v1.EnvVar{
+								{
+									Name:  "SOME_ENV",
+									Value: "test",
+								},
+								{
+									Name:  "SPRING_PROFILES_ACTIVE",
+									Value: "local,test",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	err := addSpringProfile(d, "clouddriver-ro", "accounts")
+	assert.Nil(t, err)
+	c := util.GetContainerInDeployment(d, "clouddriver-ro")
+	if assert.NotNil(t, c) {
+		assert.Equal(t, 2, len(c.Env))
+		assert.Equal(t, "local,test,accounts", c.Env[1].Value)
+	}
+}
+
 func TestAddSpringProfileExisting(t *testing.T) {
 	d := &appsv1.Deployment{
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/util/find.go
+++ b/pkg/util/find.go
@@ -14,6 +14,7 @@ import (
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
 )
 
 var errSecretNotFound = errors.New("secret not found")
@@ -92,6 +93,10 @@ func GetContainerInDeployment(dep *v12.Deployment, containerName string) *v1.Con
 		}
 	}
 	return nil
+}
+
+func IsServiceLike(svc1, svc2 string) bool {
+	return svc1 == svc2 || strings.HasPrefix(svc1, svc2+"-")
 }
 
 func UpdateSecret(secret *v1.Secret, svc string, settings map[string]interface{}, profileName string) error {

--- a/pkg/util/find_test.go
+++ b/pkg/util/find_test.go
@@ -110,3 +110,43 @@ spec:
 	assert.Equal(t, "spin-echo-files-287979322", s.ObjectMeta.Name)
 	assert.Contains(t, s.Data, "echo.yml")
 }
+
+func TestServiceLike(t *testing.T) {
+	cases := []struct {
+		name string
+		svc1 string
+		svc2 string
+		like bool
+	}{
+		{
+			"different services",
+			"gate",
+			"clouddriver",
+			false,
+		},
+		{
+			"same services",
+			"gate",
+			"gate",
+			true,
+		},
+		{
+			"specialized service",
+			"echo-scheduler",
+			"echo",
+			true,
+		},
+		{
+			"almost specialized service",
+			"echos-cheduler", // Typo on purpose
+			"echo",
+			false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.like, IsServiceLike(c.svc1, c.svc2))
+		})
+	}
+}


### PR DESCRIPTION
Prior to this change, specialized services (clouddriver-ro, echo-scheduler, ..) were being ignored. Fixes #149 