### PR TITLE
fix(ingress): fix panic when overriding endpoint with ingress

### DIFF
--- a/pkg/deploy/spindeploy/expose_ingress/transform.go
+++ b/pkg/deploy/spindeploy/expose_ingress/transform.go
@@ -149,12 +149,15 @@ func (t *ingressTransformer) setGateServerPathInDeployment(newPath string, port 
 	if c == nil {
 		return errors.New("unknown gate deployment in generated manifest")
 	}
-	t.log.Info(fmt.Sprintf("overriding readiness probe with http get to %s on port %d", newPath, port))
-	if c.ReadinessProbe.Exec != nil {
-		c.ReadinessProbe.Exec = nil
-		c.ReadinessProbe.HTTPGet = &corev1.HTTPGetAction{
-			Path: newPath,
-			Port: intstr.FromInt(port),
+	if c.ReadinessProbe == nil || c.ReadinessProbe.Exec != nil {
+		t.log.Info(fmt.Sprintf("overriding readiness probe with http get to %s on port %d", newPath, port))
+		c.ReadinessProbe = &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: newPath,
+					Port: intstr.FromInt(port),
+				},
+			},
 		}
 	}
 	return nil


### PR DESCRIPTION
On `c.ReadinessProbe == nil`