### PR TITLE
feat(unmanage): Unmanage spinnaker services

### DIFF
--- a/pkg/apis/spinnaker/interfaces/interfaces.go
+++ b/pkg/apis/spinnaker/interfaces/interfaces.go
@@ -55,6 +55,7 @@ type SpinnakerService interface {
 	GetAccountConfig() *AccountConfig
 	GetStatus() *SpinnakerServiceStatus
 	GetKustomization() map[string]ServiceKustomization
+	GetOperatorConfig() *OperatorConfig
 	DeepCopyInterface() SpinnakerService
 	DeepCopySpinnakerService() SpinnakerService
 }
@@ -120,6 +121,8 @@ type Kustomization struct {
 	Patches []Patch `json:"patches,omitempty" yaml:"patches,omitempty"`
 }
 
+// PatchStrategicMerge represents a relative path
+// to a strategic merge patch with the format https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md
 type PatchStrategicMerge string
 type PatchJson6902 string
 type Patch string
@@ -209,6 +212,9 @@ type SpinnakerServiceSpec struct {
 	// Patch Kustomization of service and deployment per service
 	// +optional
 	Kustomize map[string]ServiceKustomization `json:"kustomize,omitempty"`
+	// configuration for operator
+	// +optional
+	Operator OperatorConfig `json:"operator,omitempty"`
 }
 
 // SpinnakerDeploymentStatus represents the deployment status of a single service
@@ -306,6 +312,14 @@ type SecretInNamespaceReference struct {
 type SpinnakerAccountStatus struct {
 	InvalidReason   string        `json:"invalidReason"`
 	LastValidatedAt *v1.Timestamp `json:"lastValidatedAt"`
+}
+
+// +k8s:openapi-gen=true
+type OperatorConfig struct {
+	// Services not manage by operator
+	// +optional
+	// +listType=map
+	UnmanagedServices map[string]struct{} `json:"unmanagedServices,omitempty"`
 }
 
 var _ TypesFactory = &TypesFactoryImpl{}

--- a/pkg/apis/spinnaker/interfaces/interfaces.go
+++ b/pkg/apis/spinnaker/interfaces/interfaces.go
@@ -318,9 +318,11 @@ type SpinnakerAccountStatus struct {
 type OperatorConfig struct {
 	// Services not manage by operator
 	// +optional
-	// +listType=map
-	UnmanagedServices map[string]struct{} `json:"unmanagedServices,omitempty"`
+	// +listType=list
+	UnmanagedServices []ServiceName `json:"unmanagedServices,omitempty" yaml:"unmanagedServices,omitempty"`
 }
+
+type ServiceName string
 
 var _ TypesFactory = &TypesFactoryImpl{}
 

--- a/pkg/apis/spinnaker/v1alpha2/spinnakerservice_functions.go
+++ b/pkg/apis/spinnaker/v1alpha2/spinnakerservice_functions.go
@@ -31,6 +31,10 @@ func (s *SpinnakerService) GetKustomization() map[string]interfaces.ServiceKusto
 	return s.Spec.Kustomize
 }
 
+func (s *SpinnakerService) GetOperatorConfig() *interfaces.OperatorConfig {
+	return &s.Spec.Operator
+}
+
 func (s *SpinnakerService) GetStatus() *interfaces.SpinnakerServiceStatus {
 	return &s.Status
 }

--- a/pkg/deploy/spindeploy/save.go
+++ b/pkg/deploy/spindeploy/save.go
@@ -18,7 +18,7 @@ import (
 )
 
 // TransformManifests adjusts settings to the configuration
-func (d *Deployer) deployConfig(ctx context.Context, scheme *runtime.Scheme, gen *generated.SpinnakerGeneratedConfig, logger logr.Logger) error {
+func (d *Deployer) deployConfig(ctx context.Context, scheme *runtime.Scheme, gen *generated.SpinnakerGeneratedConfig, logger logr.Logger, unmanage map[string]struct{}) error {
 	// Set SpinnakerService instance as the owner and controller
 	count := 0
 	for _, v := range gen.Config {
@@ -36,6 +36,10 @@ func (d *Deployer) deployConfig(ctx context.Context, scheme *runtime.Scheme, gen
 	// the status. But things happen.
 	d.log.Info(fmt.Sprintf("saving %d manifests across %d services", count, len(gen.Config)))
 	for k := range gen.Config {
+		if _, ok := unmanage[k]; ok {
+			logger.Info(fmt.Sprintf("skip applying updates for %s", k))
+			continue
+		}
 		s := gen.Config[k]
 		if s.Deployment != nil {
 			logger.Info(fmt.Sprintf("saving deployment manifest for %s", k))

--- a/pkg/deploy/spindeploy/save.go
+++ b/pkg/deploy/spindeploy/save.go
@@ -18,7 +18,7 @@ import (
 )
 
 // TransformManifests adjusts settings to the configuration
-func (d *Deployer) deployConfig(ctx context.Context, scheme *runtime.Scheme, gen *generated.SpinnakerGeneratedConfig, logger logr.Logger, unmanage map[string]struct{}) error {
+func (d *Deployer) deployConfig(ctx context.Context, scheme *runtime.Scheme, gen *generated.SpinnakerGeneratedConfig, logger logr.Logger, unmanage map[string]string) error {
 	// Set SpinnakerService instance as the owner and controller
 	count := 0
 	for _, v := range gen.Config {

--- a/pkg/deploy/spindeploy/spindeploy.go
+++ b/pkg/deploy/spindeploy/spindeploy.go
@@ -122,10 +122,14 @@ func (d *Deployer) Deploy(ctx context.Context, svc interfaces.SpinnakerService, 
 		}
 	}
 
-	rLogger.Info("getting services that won't be managed by operator")
 	sUnmanaged := nSvc.GetOperatorConfig().UnmanagedServices
+	rLogger.Info(fmt.Sprintf("%d services will not be managed by operator", len(sUnmanaged)))
+	uServices := make(map[string]string)
+	for i := 0; i < len(sUnmanaged); i += 2 {
+		uServices[string(sUnmanaged[i])] = ""
+	}
 
-	if err = d.deployConfig(ctx, scheme, l, rLogger, sUnmanaged); err != nil {
+	if err = d.deployConfig(ctx, scheme, l, rLogger, uServices); err != nil {
 		return true, err
 	}
 

--- a/pkg/deploy/spindeploy/spindeploy.go
+++ b/pkg/deploy/spindeploy/spindeploy.go
@@ -122,7 +122,10 @@ func (d *Deployer) Deploy(ctx context.Context, svc interfaces.SpinnakerService, 
 		}
 	}
 
-	if err = d.deployConfig(ctx, scheme, l, rLogger); err != nil {
+	rLogger.Info("getting services that won't be managed by operator")
+	sUnmanaged := nSvc.GetOperatorConfig().UnmanagedServices
+
+	if err = d.deployConfig(ctx, scheme, l, rLogger, sUnmanaged); err != nil {
 		return true, err
 	}
 

--- a/pkg/deploy/spindeploy/spindeploy.go
+++ b/pkg/deploy/spindeploy/spindeploy.go
@@ -125,8 +125,8 @@ func (d *Deployer) Deploy(ctx context.Context, svc interfaces.SpinnakerService, 
 	sUnmanaged := nSvc.GetOperatorConfig().UnmanagedServices
 	rLogger.Info(fmt.Sprintf("%d services will not be managed by operator", len(sUnmanaged)))
 	uServices := make(map[string]string)
-	for i := 0; i < len(sUnmanaged); i += 2 {
-		uServices[string(sUnmanaged[i])] = ""
+	for _, s := range sUnmanaged {
+		uServices[string(s)] = ""
 	}
 
 	if err = d.deployConfig(ctx, scheme, l, rLogger, uServices); err != nil {


### PR DESCRIPTION
This change is about provide a way to specify Operator to not manage certain spinnaker services.

it defines a new properties field in the CRD named Operator, it will contain configurations for Operator in this case, a list of services that won't be manage by Operator.

```yml
  operator:
    unmanagedServices:
      - orca
      - echo
```

it skips the update for the `Service` & `Deployment` for the services in the `unmanagedService` list after generating the manifest configs from Halyard.
