### PR TITLE
fix(interface): add PublicPort check

### DIFF
--- a/pkg/util/runtime.go
+++ b/pkg/util/runtime.go
@@ -116,7 +116,7 @@ func GetPort(aUrl string, defaultPort int32) int32 {
 		}
 		return int32(p)
 	}
-	if defaultPort == nil {
+	if defaultPort == 0 {
 		switch u.Scheme {
 		case "http":
 			return 80

--- a/pkg/util/runtime.go
+++ b/pkg/util/runtime.go
@@ -116,11 +116,13 @@ func GetPort(aUrl string, defaultPort int32) int32 {
 		}
 		return int32(p)
 	}
-	switch u.Scheme {
-	case "http":
-		return 80
-	case "https":
-		return 443
+	if defaultPort == nil {
+		switch u.Scheme {
+		case "http":
+			return 80
+		case "https":
+			return 443
+		}
 	}
 	return defaultPort
 }


### PR DESCRIPTION
**Why:**
If `aUrl` is defined without port `u.Scheme` will override the `defaultPort` even if it is defined in `expose.service.overrides.{svc}.publicPort`.

**Fixes:**
- https://github.com/armory/spinnaker-operator/issues/204