### PR TITLE
fix(validation): validate primary account for kubernetes provider.

### DIFF
--- a/pkg/accounts/account/account.go
+++ b/pkg/accounts/account/account.go
@@ -27,6 +27,8 @@ type SpinnakerAccountType interface {
 	GetConfigAccountsKey() string
 	// GetValidationSettings returns validation settings if validation must happen
 	GetValidationSettings(spinsvc interfaces.SpinnakerService) *interfaces.ValidationSetting
+	// Key under which primary account is stored in service
+	GetPrimaryAccountsKey() string
 }
 
 // Accounts represents a single account of a certain type. It must contain a FreeForm (aka a map)

--- a/pkg/accounts/kubernetes/kubernetes.go
+++ b/pkg/accounts/kubernetes/kubernetes.go
@@ -37,6 +37,10 @@ func (k *AccountType) GetServices() []string {
 	return []string{"clouddriver"}
 }
 
+func (k *AccountType) GetPrimaryAccountsKey() string {
+	return "providers.kubernetes.primaryAccount"
+}
+
 func (k *AccountType) newAccount() *Account {
 	return &Account{
 		Env: Env{},

--- a/pkg/validate/accounts.go
+++ b/pkg/validate/accounts.go
@@ -99,6 +99,19 @@ func getAccountsFromConfig(ctx context.Context, spinSvc interfaces.SpinnakerServ
 		// Ignore, key or format don't match expectations
 		return nil, nil
 	}
+
+	primaryAccount, err := spinSvc.GetSpinnakerConfig().GetHalConfigPropString(ctx, accountType.GetPrimaryAccountsKey())
+	if primaryAccount != "" {
+		var primaryAccountExist bool
+		for _, account := range arr {
+			if primaryAccount == account["name"] {
+				primaryAccountExist = true
+			}
+		}
+		if !primaryAccountExist {
+			return nil, fmt.Errorf("primary account defined on '%s' is not present under '%s'", accountType.GetPrimaryAccountsKey(), accountType.GetConfigAccountsKey())
+		}
+	}
 	return accounts.FromSpinnakerConfigSlice(ctx, accountType, arr, false)
 }
 

--- a/pkg/validate/accounts_test.go
+++ b/pkg/validate/accounts_test.go
@@ -37,6 +37,28 @@ spec:
 	}
 }
 
+func TestPrimaryAccount(t *testing.T) {
+	s := `
+kind: SpinnakerService
+spec:
+  spinnakerConfig:
+    config:
+      providers:
+        kubernetes:
+          primaryAccount: acc3
+          accounts:
+          - name: acc1
+            kubeconfigFile: test-1.yml
+          - name: acc2
+            kubeconfigFile: test-2.yml
+`
+	spinsvc := interfaces.DefaultTypesFactory.NewService()
+	if assert.Nil(t, yaml.Unmarshal([]byte(s), spinsvc)) {
+		_, err := getAccountsFromConfig(context.TODO(), spinsvc, &kubernetes.AccountType{})
+		assert.NotNil(t, err)
+	}
+}
+
 func TestNoAccounts(t *testing.T) {
 	s := `
 kind: SpinnakerService


### PR DESCRIPTION
This PR enables Operator to validate if the primary account defined on `providers.kubernetes.primaryAccount` is present on Kubernetes accounts.

example output error message: 

```
primary account defined on 'providers.kubernetes.primaryAccount' is not present under 'providers.kubernetes.accounts'
```

