### PR TITLE
fix(expose): override public service port

### DIFF
--- a/pkg/deploy/spindeploy/expose_service/testdata/spinsvc_expose.yml
+++ b/pkg/deploy/spindeploy/expose_service/testdata/spinsvc_expose.yml
@@ -21,7 +21,6 @@ spec:
     type: service
     service:
       type: LoadBalancer
-      publicPort: 80
       annotations:
         "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http"
       overrides: {}

--- a/pkg/deploy/spindeploy/expose_service/testdata/spinsvc_expose_publicPort.yml
+++ b/pkg/deploy/spindeploy/expose_service/testdata/spinsvc_expose_publicPort.yml
@@ -1,0 +1,30 @@
+apiVersion: spinnaker.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+  namespace: ns1
+spec:
+  spinnakerConfig:
+    config:
+      version: 1.15.1
+      persistentStorage:
+        persistentStoreType: s3
+        s3:
+          bucket: my-bucket
+          region: us-west-2
+          rootFolder: front50
+    profiles:
+      gate:
+        default:
+          apiPort: 8085
+  expose:
+    type: service
+    service:
+      type: LoadBalancer
+      publicPort: 80
+      annotations:
+        "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "http"
+      overrides: {}
+status:
+  apiUrl: http://acme.com
+  uiUrl: http://acme.com

--- a/pkg/deploy/spindeploy/expose_service/testdata/spinsvc_override_port.yml
+++ b/pkg/deploy/spindeploy/expose_service/testdata/spinsvc_override_port.yml
@@ -1,0 +1,34 @@
+apiVersion: spinnaker.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+  namespace: ns1
+spec:
+  spinnakerConfig:
+    config:
+      version: 1.23.3
+      persistentStorage:
+        persistentStoreType: s3
+        s3:
+          bucket: my-bucket
+          region: us-west-2
+          rootFolder: front50
+      security:
+        apiSecurity:
+          overrideBaseUrl: http://acme.com
+          ssl:
+            enabled: false
+        uiSecurity:
+          overrideBaseUrl: http://acme.com
+          ssl:
+            enabled: false
+  expose:
+    type: service
+    service:
+      type: LoadBalancer
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+      overrides:
+        gate:
+          type: ClusterIP
+          publicPort: 8089

--- a/pkg/deploy/spindeploy/expose_service/transform.go
+++ b/pkg/deploy/spindeploy/expose_service/transform.go
@@ -149,20 +149,17 @@ func ApplyExposeServiceConfig(exp *interfaces.ExposeConfig, svc *corev1.Service,
 }
 
 func (t *exposeTransformer) applyPortChanges(ctx context.Context, portName string, portDefault int32, svc *corev1.Service) error {
-	for i := 0; i < len(svc.Spec.Ports); i++ {
-		// avoid to override patches
-		if svc.Spec.Ports[i].Name == "" {
-			svc.Spec.Ports[i].Port = portDefault
-			svc.Spec.Ports[i].Name = portName
-			if strings.Contains(portName, "gate") {
-				// ignore error, property may be missing
-				if targetPort, _ := t.svc.GetSpinnakerConfig().GetServiceConfigPropString(ctx, "gate", "server.port"); targetPort != "" {
-					intTargetPort, err := strconv.ParseInt(targetPort, 10, 32)
-					if err != nil {
-						return err
-					}
-					svc.Spec.Ports[i].TargetPort = intstr.IntOrString{IntVal: int32(intTargetPort)}
+	if len(svc.Spec.Ports) > 0 {
+		svc.Spec.Ports[0].Port = portDefault
+		svc.Spec.Ports[0].Name = portName
+		if strings.Contains(portName, "gate") {
+			// ignore error, property may be missing
+			if targetPort, _ := t.svc.GetSpinnakerConfig().GetServiceConfigPropString(ctx, "gate", "server.port"); targetPort != "" {
+				intTargetPort, err := strconv.ParseInt(targetPort, 10, 32)
+				if err != nil {
+					return err
 				}
+				svc.Spec.Ports[0].TargetPort = intstr.IntOrString{IntVal: int32(intTargetPort)}
 			}
 		}
 	}

--- a/pkg/deploy/spindeploy/expose_service/transform.go
+++ b/pkg/deploy/spindeploy/expose_service/transform.go
@@ -149,17 +149,20 @@ func ApplyExposeServiceConfig(exp *interfaces.ExposeConfig, svc *corev1.Service,
 }
 
 func (t *exposeTransformer) applyPortChanges(ctx context.Context, portName string, portDefault int32, svc *corev1.Service) error {
-	if len(svc.Spec.Ports) > 0 {
-		svc.Spec.Ports[0].Port = portDefault
-		svc.Spec.Ports[0].Name = portName
-		if strings.Contains(portName, "gate") {
-			// ignore error, property may be missing
-			if targetPort, _ := t.svc.GetSpinnakerConfig().GetServiceConfigPropString(ctx, "gate", "server.port"); targetPort != "" {
-				intTargetPort, err := strconv.ParseInt(targetPort, 10, 32)
-				if err != nil {
-					return err
+	for i := 0; i < len(svc.Spec.Ports); i++ {
+		// avoid to override patches
+		if svc.Spec.Ports[i].Name == "" {
+			svc.Spec.Ports[i].Port = portDefault
+			svc.Spec.Ports[i].Name = portName
+			if strings.Contains(portName, "gate") {
+				// ignore error, property may be missing
+				if targetPort, _ := t.svc.GetSpinnakerConfig().GetServiceConfigPropString(ctx, "gate", "server.port"); targetPort != "" {
+					intTargetPort, err := strconv.ParseInt(targetPort, 10, 32)
+					if err != nil {
+						return err
+					}
+					svc.Spec.Ports[i].TargetPort = intstr.IntOrString{IntVal: int32(intTargetPort)}
 				}
-				svc.Spec.Ports[0].TargetPort = intstr.IntOrString{IntVal: int32(intTargetPort)}
 			}
 		}
 	}

--- a/pkg/deploy/spindeploy/expose_service/transform_test.go
+++ b/pkg/deploy/spindeploy/expose_service/transform_test.go
@@ -39,6 +39,20 @@ func TestTransformManifests_ExposedWithOverrideUrlChangingPort(t *testing.T) {
 	assert.Equal(t, expected, gen.Config["gate"].Service)
 }
 
+func TestTransformManifests_ExposedWithOverridePort(t *testing.T) {
+	tr, spinSvc := transformertest.SetupTransformerFromSpinFile(&TransformerGenerator{}, "testdata/spinsvc_expose_publicPort.yml", t)
+	gen := &generated.SpinnakerGeneratedConfig{}
+	test.AddServiceToGenConfig(gen, "gate", "testdata/input_service.yml", t)
+	err := spinSvc.GetSpinnakerConfig().SetHalConfigProp("security.apiSecurity.overrideBaseUrl", "https://my-api.spin.com")
+
+	err = tr.TransformManifests(context.TODO(), gen)
+	assert.Nil(t, err)
+
+	expected := &corev1.Service{}
+	test.ReadYamlFile("testdata/output_service_lb.yml", expected, t)
+	assert.Equal(t, expected, gen.Config["gate"].Service)
+}
+
 func TestTransformManifests_ExposedAggregatedAnnotations(t *testing.T) {
 	s := `
 apiVersion: spinnaker.io/v1alpha2


### PR DESCRIPTION
This PR enables the Operator to override the port if `expose.service.overrides.{service}.publicPort ` is defined.

Fixes #204 

related PR https://github.com/armory/spinnaker-operator/pull/208 